### PR TITLE
Change hooks-server port and add some info on hooks failure

### DIFF
--- a/04-data-quality-checks-with-lakeFS-hooks/actions.yaml
+++ b/04-data-quality-checks-with-lakeFS-hooks/actions.yaml
@@ -9,7 +9,7 @@ hooks:
     type: webhook
     description: Validate file formats
     properties:
-      url: "http://lakefs-hooks:5001/webhooks/format"
+      url: "http://lakefs-hooks:5000/webhooks/format"
       query_params:
         allow: ["parquet", "delta_lake"]
         prefix: analytics/

--- a/04-data-quality-checks-with-lakeFS-hooks/lakeFS-hooks-demo.ipynb
+++ b/04-data-quality-checks-with-lakeFS-hooks/lakeFS-hooks-demo.ipynb
@@ -234,7 +234,7 @@
    "source": [
     "## Uploading actions.yaml config file to staging branch\n",
     "\n",
-    "* Hooks config file `actions.yaml` needs to be uploaded to the branch on which the tests are run. i.e., we want to run data quality tests on staging branch before merging the data into production.\n",
+    "* We want to run data quality tests on staging branch before merging the data into production. Hooks config file `actions.yaml` needs to be in the branch on which the tests are run.\n",
     "\n",
     "* So add `_lakefs_actions/actions.yaml` to staging branch\n",
     "* `actions.yaml` contains a pre-merge hook configured to check for file format validation."
@@ -423,6 +423,16 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b831cb9b",
+   "metadata": {},
+   "source": [
+    "### Why did the above failed?\n",
+    "If you look deeper into the error log, you'll see that the merge request failed with status code '412' (precondition failed). The actions file was executed and blocked a commit with a csv file to merge into main.\n",
+    "* Hint: You can see previous actions run [here](http://localhost:8000/repositories/example/actions)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This flow is a great addition to our ability to show the ci/cd capabilities and promise! I enjoyed executing it and was a very smooth experience.
- Added/changed minor wording related to the hooks for clarity.
- Changed the port to `5000` so that the hooks error is not `connection refused` which means the request didn't reach the hooks-server. When reaching the server, the actual error is `precondition failed` since the checks were unsuccessful:
```
Response:
HTTP/1.1 400 BAD REQUEST
Connection: close
Content-Length: 585
Content-Type: application/json
Date: Thu, 20 Oct 2022 09:29:04 GMT
Server: Werkzeug/2.2.2 Python/3.9.15

{"errors":[{"error":"file format not allowed","path":"analytics/movies-by-type-csv/type=Movie/part-00000-9d34e728-dc34-42f9-b62d-d110211414b4.c000.csv"},{"error":"file format not allowed","path":"analytics/movies-by-type-csv/type=Movie/part-00000-ba04e02d-f3fb-4426-88f7-20f11adafec7.c000.csv"},{"error":"file format not allowed","path":"analytics/movies-by-type-csv/type=TV Show/part-00000-9d34e728-dc34-42f9-b62d-d110211414b4.c000.csv"},{"error":"file format not allowed","path":"analytics/movies-by-type-csv/type=TV Show/part-00000-ba04e02d-f3fb-4426-88f7-20f11adafec7.c000.csv"}]}
Error: webhook request failed (status code: 400)
```