### PR TITLE
Expand data lineage to auditing

### DIFF
--- a/08-data-lineage/Data Lineage.ipynb
+++ b/08-data-lineage/Data Lineage.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "storageNamespace = 's3://iddos3/lineagetest/ramndom234ds/' # e.g. \"s3://username-lakefs-cloud/\""
+    "storageNamespace = 's3://' # e.g. \"s3://username-lakefs-cloud/\""
    ]
   },
   {

--- a/08-data-lineage/Data Lineage.ipynb
+++ b/08-data-lineage/Data Lineage.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "storageNamespace = '' # e.g. \"s3://username-lakefs-cloud/\""
+    "storageNamespace = 's3://iddos3/lineagetest/ramndom234ds/' # e.g. \"s3://username-lakefs-cloud/\""
    ]
   },
   {
@@ -539,17 +539,124 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "681538a9-5146-4201-99c8-148222aa7a10",
+   "cell_type": "markdown",
+   "id": "ba99c5a6-7df6-42b5-9a3f-74ba3d0f67c1",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "# Auditing\n",
+    "\n",
+    "## Creating an Engineering group and adding an Engineer1 user to the group"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "a290f98f-6169-470a-834d-4c22115a0877",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.auth.create_group(\n",
+    "    group_creation=models.GroupCreation(\n",
+    "        id='Engineering'))\n",
+    "\n",
+    "# Creating an engineer1 User\n",
+    "\n",
+    "client.auth.create_user(\n",
+    "    user_creation=models.UserCreation(\n",
+    "        id='engineer1'))\n",
+    "\n",
+    "# Adding the engineer1 User to the group\n",
+    "\n",
+    "client.auth.add_group_membership(\n",
+    "    group_id='Engineering',\n",
+    "    user_id='engineer1')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52401982-1e2f-467b-8da4-5ae0882d8948",
+   "metadata": {},
+   "source": [
+    "## Generating credentials and setting up a client for the Engineer1 User"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c70df586-65d5-4e4f-8a75-a0eab849f073",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "credentials = client.auth.create_credentials(user_id='engineer1')\n",
+    "print(credentials)\n",
+    "engineer1AccessKey = credentials.access_key_id\n",
+    "engineer1SecretKey = credentials.secret_access_key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e7cd7d6-db1c-4f1a-8910-f6cf9c992a51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# lakeFS credentials and endpoint\n",
+    "configuration = lakefs_client.Configuration()\n",
+    "configuration.username = engineer1AccessKey\n",
+    "configuration.password = engineer1SecretKey\n",
+    "configuration.host = lakefsEndPoint\n",
+    "\n",
+    "# Creating a client for engineer1\n",
+    "engineer1Client = LakeFSClient(configuration)\n",
+    "print(\"Created lakeFS client for engineer1.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a921281-afcc-4dae-978a-f47e93ecb452",
+   "metadata": {},
+   "source": [
+    "## Providing Engineers with Full Access to the Filesystem"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9015d02d-c7bd-4705-a373-579ba1ba47df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.auth.attach_policy_to_group(\n",
+    "    group_id='Engineering',\n",
+    "    policy_id='FSFullAccess')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52df13af-1632-46e2-b33b-d3dfcaab7052",
+   "metadata": {},
+   "source": [
+    "## Engineer1 will now read the salary of Finance... "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25999280-c1ac-45c9-b958-7472950b4392",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "engineer1Client.objects.list_objects(\n",
+    "    repository=repo,\n",
+    "    ref='main',\n",
+    "    prefix='partitioned_data/department=Finance/'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c39d46b-2f84-44a6-8783-e39bb5e27c00",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
After partitioning by department, having a member of engineering access data of a different team as an example of an auditable action that will appear later on in the audit logs. 