### PR TITLE
Fix the lakeFS connection in airflow

### DIFF
--- a/06-airflow-dag-example/docker-compose.yml
+++ b/06-airflow-dag-example/docker-compose.yml
@@ -7,13 +7,11 @@ x-airflow-common:
   image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.5.0}
   environment:
     &airflow-common-env
-    AIRFLOW_CONN_LAKEFS: '{
-        "conn_type": "HTTP",
-        "host": "http://lakefs:8000/api/v1",
-        "extra": {
-            "access_key_id": "AKIAIOSFODNN7EXAMPLE",
-            "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-        }
+    AIRFLOW_CONN_FOO-LAKEFS: '{
+        "conn_type": "lakefs",
+        "host": "http://lakefs:8000/",
+        "login": "AKIAIOSFODNN7EXAMPLE",
+        "password": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
       }'
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow

--- a/06-airflow-dag-example/docker-compose.yml
+++ b/06-airflow-dag-example/docker-compose.yml
@@ -7,7 +7,7 @@ x-airflow-common:
   image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.5.0}
   environment:
     &airflow-common-env
-    AIRFLOW_CONN_FOO-LAKEFS: '{
+    AIRFLOW_CONN_LAKEFS: '{
         "conn_type": "lakefs",
         "host": "http://lakefs:8000/",
         "login": "AKIAIOSFODNN7EXAMPLE",


### PR DESCRIPTION
The existing connection is defined as an `HTTP` connection, and the DAG task tails with 

    access_key_id must be specified in the lakeFS connection details

This is despite a successful test from the connection page. (As part of exploration I created a connection manually; connections defined as environment variables are [not listed on the connections page or CLI](https://github.com/apache/airflow/issues/17852))

This PR changes the connection defined in the environment variable to a `lakeFS` one. 
