### PR TITLE
Add automated testing to notebooks

### DIFF
--- a/.github/workflows/check-notebooks.yml
+++ b/.github/workflows/check-notebooks.yml
@@ -2,7 +2,7 @@ name: "Check notebooks"
 on:
   push:
     branches:
-      # - 'master'
+      - 'master'
   pull_request:
 
 jobs:

--- a/.github/workflows/check-notebooks.yml
+++ b/.github/workflows/check-notebooks.yml
@@ -1,0 +1,62 @@
+name: "Check notebooks"
+on:
+  push:
+    branches:
+      # - 'master'
+  pull_request:
+
+jobs:
+  check-notebooks:
+    # runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Build container
+        run: docker-compose pull && docker-compose build && docker-compose up -d
+
+      - name: Wait until Jupyter container is up
+        run: |
+          while ! nc -z localhost 8888; do
+            sleep 1
+          done
+
+      - name: Wait until lakeFS container is properly up
+        run: |
+          while ! curl -s http://localhost:8000/_health; do
+            sleep 1
+          done
+
+      - name: Wait until lakeFS container is up and ready and reachable from Jupyter
+        run: |
+          timeout=$((SECONDS + 300))  # Set timeout to 5 minutes from now
+          while [ $SECONDS -lt $timeout ]; do
+              output=$(docker exec $(docker ps -q --filter expose=8888) wget -q -O - http://lakefs:8000/_health 2>&1)
+              if [[ $output == alive* ]]; then
+                  echo "Health check returned: $output"
+                  break
+              fi
+              sleep 5  # Wait for 1 second before trying again
+          done
+
+          if [ $SECONDS -ge $timeout ]; then
+              echo "Timeout reached, Health check did not return 'alive' within 5 minutes"
+              exit 1
+          fi
+
+      - name: Container status
+        run: |
+          docker ps -a
+
+      - name: Run notebooks
+        run: |
+          # docker exec $(docker ps -q --filter expose=8888) papermill "/home/jovyan/dev-test.ipynb"
+
+          cd notebooks && \
+          find . -name "*.ipynb" | \
+          grep -vFf ../.github/workflows/notebooks_to_exclude.txt | \
+          grep -v .ipynb_checkpoints | \
+          xargs -I {} docker exec $(docker ps -q --filter expose=8888) papermill "/home/jovyan/{}"

--- a/.github/workflows/notebooks_to_exclude.txt
+++ b/.github/workflows/notebooks_to_exclude.txt
@@ -1,0 +1,17 @@
+demos-and-talks/chaos-engineering_dais22.ipynb
+demos-and-talks/lakeFS-DeltaLake-multi-table-transaction-consistency.ipynb
+demos-and-talks/lakeFSOnSynapse.ipynb
+demos-and-talks/ml-reproducibility.ipynb
+demos-and-talks/ml_reproducibility/file_utils.ipynb
+demos-and-talks/ml_reproducibility/ml_utils.ipynb
+hooks-demo.ipynb
+hooks-schema-and-pii-validation.ipynb
+hooks-schema-validation.ipynb
+rbac-demo.ipynb
+reprocess-data/etl.ipynb
+reprocess-data/reprocessing.ipynb
+write-audit-publish/wap-delta.ipynb
+write-audit-publish/wap-hudi.ipynb
+write-audit-publish/wap-iceberg.ipynb
+write-audit-publish/wap-lakefs.ipynb
+write-audit-publish/wap-nessie.ipynb

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -29,5 +29,8 @@ RUN mkdir -p /home/jovyan/.ipython/profile_default/startup
 COPY ipython/startup/00-prettytables.py /home/jovyan/.ipython/profile_default/startup
 COPY ipython/startup/README /home/jovyan/.ipython/profile_default/startup
 
+# Set environment vars so that pyspark is available outside of Jupyter
+ENV PYTHONPATH=$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.9.5-src.zip:$PYTHONPATH
+
 # Disable the "Would you like to receive official Jupyter news?" popup
 RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"

--- a/jupyter/requirements.txt
+++ b/jupyter/requirements.txt
@@ -3,3 +3,4 @@ jupysql>=0.5.2
 boto3
 jupyter_contrib_nbextensions
 tabulate
+papermill

--- a/notebooks/data-lineage.ipynb
+++ b/notebooks/data-lineage.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "9b2c8fa0-1702-411a-b11c-3190679bf31c",
    "metadata": {},
@@ -14,7 +13,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "6de52058-394b-47b3-9821-872153d88ed3",
    "metadata": {},
@@ -27,7 +25,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "9bae3b19-1946-4650-882e-0f491c398044",
    "metadata": {
@@ -40,7 +37,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "183fe9db-8199-49b8-920f-0de987537b6b",
    "metadata": {},
@@ -63,7 +59,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "0e6130e3-8f97-409f-b89f-c03eb71771b9",
    "metadata": {
@@ -86,7 +81,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c15482c5-ce34-4107-b36d-aa41c3966678",
    "metadata": {},
@@ -95,7 +89,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "b7623f2b-37b0-497f-99eb-3d1a391b5d78",
    "metadata": {
@@ -120,7 +113,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "70fcf734-8b50-4c82-a42d-a16c3a007a38",
    "metadata": {
@@ -153,7 +145,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "41c991ae-c9d1-4ca8-934e-ea3d80285037",
    "metadata": {},
@@ -180,7 +171,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "28ec2c10-2fd7-4446-95de-6393af334af5",
    "metadata": {},
@@ -217,7 +207,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "9539326e-bf18-469c-9069-542f38945d7f",
    "metadata": {},
@@ -248,7 +237,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c093db8e-68d9-409f-bde7-73ee4ceca5a5",
    "metadata": {},
@@ -274,7 +262,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "addf2911-8cb2-4cad-b9fd-ed874e21721e",
    "metadata": {},
@@ -283,7 +270,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "107bf504-ce85-490b-86c0-c6eb5d665454",
    "metadata": {},
@@ -292,7 +278,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "23408882-333a-413a-be3c-2d799e706a72",
    "metadata": {},
@@ -334,7 +319,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ed1629fe-2b8d-442b-bb42-9a9e1779875e",
    "metadata": {},
@@ -362,7 +346,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "70239947-a305-4f3a-a275-c9a528bafce6",
    "metadata": {},
@@ -406,7 +389,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "f18b8e20-2b4b-465f-9fee-055a6b2d6b5d",
    "metadata": {
@@ -436,7 +418,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "cc1d2dc7-3238-4fd0-8316-a0b625dad86d",
    "metadata": {
@@ -549,7 +530,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "e879bc6f-778d-479f-b174-5ac74c2ddb7a",
    "metadata": {
@@ -574,7 +554,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "aa58149f-2440-42b0-a719-926321271f8e",
    "metadata": {
@@ -603,7 +582,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "b7046c7c-b4f2-44c7-8e48-5845808d47c0",
    "metadata": {
@@ -629,7 +607,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "adf0a1a5-f850-4267-9d18-d47b3d8c9d9f",
    "metadata": {
@@ -666,7 +643,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "dfdfac34-4f04-4e4c-9d4d-ce1e5b9ffcd1",
    "metadata": {},
@@ -675,7 +651,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "807c8996-9bfa-48ba-ab33-05298b6a3f08",
    "metadata": {},
@@ -684,7 +659,24 @@
    ]
   },
   {
-   "attachments": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3da7dbf5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The section below will only work on lakeFS cloud. \n",
+    "# This cell will stop execution which is useful if the notebook has been \n",
+    "# run from the top or is being run as part of automated testing.\n",
+    "\n",
+    "class StopExecution(Exception):\n",
+    "    def _render_traceback_(self):\n",
+    "        pass\n",
+    "    \n",
+    "raise StopExecution"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "6027f63c-630f-46e9-8db6-5785f2c58556",
    "metadata": {},
@@ -693,7 +685,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ba99c5a6-7df6-42b5-9a3f-74ba3d0f67c1",
    "metadata": {},
@@ -704,7 +695,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "0a0e50ca-2147-47d4-bd2f-7c625d5a4c3d",
    "metadata": {},
@@ -727,7 +717,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "6a190e2c-43a5-4e96-9b75-3f118a51fbfc",
    "metadata": {},
@@ -750,7 +739,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ba2083ab-f6f1-40d8-9402-8796af72c166",
    "metadata": {},
@@ -773,7 +761,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "52401982-1e2f-467b-8da4-5ae0882d8948",
    "metadata": {},
@@ -817,7 +804,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "9a921281-afcc-4dae-978a-f47e93ecb452",
    "metadata": {},
@@ -840,7 +826,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "52df13af-1632-46e2-b33b-d3dfcaab7052",
    "metadata": {},
@@ -863,14 +848,6 @@
     "    prefix='partitioned_data/department=Finance/'\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4ed9c4ee-65c0-499b-bb29-ea595b1b5414",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/ml-experimentation-wine-quality-prediction.ipynb
+++ b/notebooks/ml-experimentation-wine-quality-prediction.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "2871c4c7",
    "metadata": {},
@@ -16,7 +15,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "251d5405",
    "metadata": {},
@@ -27,7 +25,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "66e50753",
    "metadata": {},
@@ -50,7 +47,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "2b3275a1",
    "metadata": {},
@@ -71,7 +67,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "575c81d5",
    "metadata": {},
@@ -80,7 +75,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "0c5ba145",
    "metadata": {},
@@ -103,7 +97,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "7239dca6",
    "metadata": {},
@@ -134,7 +127,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "d30db010",
    "metadata": {},
@@ -161,7 +153,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "4d5f17b5",
    "metadata": {},
@@ -198,7 +189,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "10d941bb",
    "metadata": {},
@@ -222,10 +212,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9d739edf",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "! pip install duckdb s3fs"
+    "# boto3 is re-installed here due to issue detailed in https://github.com/boto/boto3/issues/3648\n",
+    "! pip install duckdb s3fs boto3"
    ]
   },
   {
@@ -278,7 +271,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "9ffa3efd-2c1c-4e0f-acb2-ec84ea5f2744",
    "metadata": {},
@@ -322,7 +314,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "39f4e0b6",
    "metadata": {},
@@ -331,7 +322,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "744be8ac",
    "metadata": {},
@@ -340,7 +330,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "1d07acc4",
    "metadata": {},
@@ -377,7 +366,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "cb22215b",
    "metadata": {},
@@ -446,7 +434,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "bdf4dd66",
    "metadata": {},
@@ -520,7 +507,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3db7cf1f",
    "metadata": {},
@@ -561,7 +547,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "6a5292c3",
    "metadata": {},
@@ -570,7 +555,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "19e842d8",
    "metadata": {},
@@ -579,7 +563,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "4dda0ce2",
    "metadata": {},
@@ -613,7 +596,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "be968799",
    "metadata": {},
@@ -638,7 +620,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "b3ddc105",
    "metadata": {},
@@ -689,7 +670,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "5a2c03e7",
    "metadata": {},
@@ -818,7 +798,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "a7387d6d",
    "metadata": {},
@@ -896,7 +875,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "24d452ff",
    "metadata": {},
@@ -981,7 +959,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c24490dd",
    "metadata": {},
@@ -1026,7 +1003,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c9748ee0",
    "metadata": {},
@@ -1065,7 +1041,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "218a4dd7",
    "metadata": {},
@@ -1074,7 +1049,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "a690bb05",
    "metadata": {},
@@ -1108,7 +1082,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "65107bda",
    "metadata": {},
@@ -1132,7 +1105,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "03c6aa71",
    "metadata": {},
@@ -1183,7 +1155,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "6c032e7c",
    "metadata": {},
@@ -1300,7 +1271,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "f7f2af22",
    "metadata": {},
@@ -1378,7 +1348,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "d86f8fbb",
    "metadata": {},
@@ -1452,7 +1421,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "623def87",
    "metadata": {},
@@ -1497,7 +1465,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "fa126f1f",
    "metadata": {},
@@ -1536,7 +1503,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "1fc9722b",
    "metadata": {},

--- a/notebooks/spark-demo.ipynb
+++ b/notebooks/spark-demo.ipynb
@@ -466,57 +466,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a39c242-ac7d-4e56-8099-51e667e2c9c8",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "## Option A: Experimentation fails, so just delete the new branch"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1c6f3460",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "lakefs.branches.delete_branch(\n",
-    "    repository=repo.id,\n",
-    "    branch=newBranch)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "63704bc3",
    "metadata": {},
    "source": [
-    "## Option B: Experimentation succeeds, so merge new branch to the main branch (atomic promotion to production)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "30cb92fd",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "lakefs.refs.merge_into_branch(\n",
-    "    repository=repo.id,\n",
-    "    source_ref=newBranch, \n",
-    "    destination_branch=sourceBranch)"
+    "## Option A: Experimentation succeeds, so merge new branch to the main branch (atomic promotion to production)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6ca2c741",
+   "id": "72d719ff-e734-4080-a94d-4f6685051fc7",
    "metadata": {},
    "source": [
-    "## Diff between the new branch and the source branch"
+    "### Diff between the new branch and the source branch"
    ]
   },
   {
@@ -543,10 +504,33 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7aa1778",
+   "id": "587a5f10-3d9d-4e09-a618-eb54bc6cc592",
    "metadata": {},
    "source": [
-    "## If you merged new branch to the main branch then you can atomically rollback all changes"
+    "### Do the merge"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30cb92fd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "lakefs.refs.merge_into_branch(\n",
+    "    repository=repo.id,\n",
+    "    source_ref=newBranch, \n",
+    "    destination_branch=sourceBranch)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d38f0594-731f-4dbc-98ee-a81bf8c22edf",
+   "metadata": {},
+   "source": [
+    "### If you merged new branch to the main branch then you can atomically rollback all changes"
    ]
   },
   {
@@ -563,6 +547,33 @@
     "    branch=sourceBranch, \n",
     "    revert_creation=RevertCreation(\n",
     "        ref=sourceBranch, parent_number=1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc41eddd-5e09-404c-bd2b-70a62080a141",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Option B: Experimentation fails, so just delete the new branch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c6f3460",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Uncomment if you want to run this, but subsequent cells depend on the \n",
+    "# branch still being present\n",
+    "\n",
+    "#lakefs.branches.delete_branch(\n",
+    "#    repository=repo.id,\n",
+    "#    branch=newBranch)"
    ]
   },
   {


### PR DESCRIPTION
This uses [Papermill](https://papermill.readthedocs.io/) to run the sample notebooks with the provided Docker Compose in this repository. 

Some notebooks are excluded (`notebooks_to_exclude.txt`), in cases where: 

- The notebook is not runnable in its current state (but included in the repository for reference)
- The notebook throws an exception by design (e.g. showing hooks making a merge fail)

In the case of the latter, it may be we spend some time working out how to code for an excepted exception, but for now these are excluded. 

---

The PR also includes some minor fixes for some of the notebooks: 

- Halt execution before the lakeFS cloud bit
- Rearrange final sections so that the notebook doesn't fail testing because of subsequent actions on a deleted branch
- Fix boto3 dep error
