### PR TITLE
Fixing labelbox readme instructions

### DIFF
--- a/standalone/labelbox-integration/README.md
+++ b/standalone/labelbox-integration/README.md
@@ -14,7 +14,7 @@ This repository includes a Jupyter Notebook which you can run on your local mach
 1. Start by cloning this repository:
 
    ```bash
-   git clone https://github.com/treeverse/lakeFS-samples && cd lakeFS-samples/12-labelbox-integration
+   git clone https://github.com/treeverse/lakeFS-samples && cd lakeFS-samples/standalone/labelbox-integration
    ```
 
 2. Run following commands to download and run Docker container which includes Python, Spark, Jupyter Notebook, JDK, Hadoop binaries and lakeFS Python client (Docker image size is around 4GB):


### PR DESCRIPTION
The location of the file was changed without changing the instructions on how to run. 