### PR TITLE
Fix branch name in action trigger, update README to show status of main only

### DIFF
--- a/.github/workflows/check-notebooks.yml
+++ b/.github/workflows/check-notebooks.yml
@@ -2,7 +2,7 @@ name: "Check notebooks"
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
     paths-ignore:
       - '01_standalone_examples/**'
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lakefs-samples
 
-[![Check notebooks](https://github.com/treeverse/lakeFS-samples/actions/workflows/check-notebooks.yml/badge.svg)](https://github.com/treeverse/lakeFS-samples/actions/workflows/check-notebooks.yml)
+[![Check notebooks](https://github.com/treeverse/lakeFS-samples/actions/workflows/check-notebooks.yml/badge.svg?branch=main)](https://github.com/treeverse/lakeFS-samples/actions/workflows/check-notebooks.yml)
 
 _Incorporating the Docker Compose formally known as **Everything Bagel**._
 


### PR DESCRIPTION
Trigger erroneously names `master` instead of `main` as branch to trigger on for a `push`. 

Refine the status badge on the README to only show status of `main` action runs. 