### PR TITLE
each compose file to set unique container names

### DIFF
--- a/01_standalone_examples/airflow-02/docker-compose.yml
+++ b/01_standalone_examples/airflow-02/docker-compose.yml
@@ -45,6 +45,7 @@
 # Feel free to modify this file to suit your needs.
 ---
 version: '3.8'
+name: lakefs-airflow-example-2
 x-airflow-common:
   &airflow-common
   # In order to add custom dependencies or upgrade provider packages you can use your extended image.
@@ -324,7 +325,7 @@ services:
         
   lakefs:
     extends:
-      file: ../docker-compose.yml
+      file: ../../docker-compose.yml
       service: lakefs
 
   lakefs-setup:
@@ -349,12 +350,12 @@ services:
 
   minio-setup:
     extends:
-      file: ../docker-compose.yml
+      file: ../../docker-compose.yml
       service: minio-setup
 
   minio:
     extends:
-      file: ../docker-compose.yml
+      file: ../../docker-compose.yml
       service: minio
 
 volumes:

--- a/01_standalone_examples/dagster-integration/docker-compose.yml
+++ b/01_standalone_examples/dagster-integration/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '3.8'
+name: lakefs-dagster-example
 services:
   lakefs:
     extends:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 version: "3.5"
-name: lakefs-with-jupyter
+name: lakefs-samples
 services:
   lakefs:
     image: treeverse/lakefs:0.104.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,8 @@
 version: "3.5"
+name: lakefs-with-jupyter
 services:
-
   lakefs:
     image: treeverse/lakefs:0.104.0
-    container_name: lakefs
     depends_on:
       - minio-setup
     ports:
@@ -56,7 +55,6 @@ services:
 
   minio-setup:
     image: minio/mc:RELEASE.2023-05-18T16-59-00Z
-    container_name: minio-setup
     environment:
         - MC_HOST_lakefs=http://minioadmin:minioadmin@minio:9000
     depends_on:
@@ -71,7 +69,6 @@ services:
 
   minio:
     image: minio/minio:RELEASE.2023-05-18T00-05-36Z
-    container_name: minio
     ports:
       - "9000:9000"
       - "9001:9001"
@@ -81,7 +78,6 @@ services:
   # Log level is set to WARN because of noisy stdout problem
   # -> See https://github.com/jupyter-server/jupyter_server/issues/1279
     build: jupyter
-    container_name: jupyter-notebook
     environment:
       - NOTEBOOK_ARGS=--log-level='WARN' --NotebookApp.token='' --NotebookApp.password='' --notebook-dir=/home/jovyan/notebooks
     ports:
@@ -94,7 +90,6 @@ services:
   lakefs-webhooks:
     build: lakeFS-hooks
     image: lakefs-hooks
-    container_name: lakefs-hooks
     depends_on:
       - lakefs
     environment:


### PR DESCRIPTION
This will avoid name collisions of between examples, so it's possible to ctrl-c one example and start another without having to `docker-compose down` each time.
This also has the benefit of not removing the container's state between such runs