### PR TITLE
Remove embedded hooks server (instructions added to notebook)

### DIFF
--- a/00_notebooks/hooks-webhooks-demo.ipynb
+++ b/00_notebooks/hooks-webhooks-demo.ipynb
@@ -14,6 +14,39 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ab32c1d9-d36b-48d8-8d71-20d29e8480af",
+   "metadata": {},
+   "source": [
+    "## Pre-requisites\n",
+    "\n",
+    "To use this demo you need to have a webhook server running that is accessible from your lakeFS server. The provided action assumes that it's called `lakefs-hooks` - if it's on a different host or IP then amend the `./hooks/actions.yaml` file. \n",
+    "\n",
+    "If you're using the lakeFS-samples Docker Compose to run lakeFS you can spin up a webhook server by doing the following: \n",
+    "\n",
+    "1. Clone the repository\n",
+    "\n",
+    "    ```\n",
+    "    git clone https://github.com/treeverse/lakeFS-hooks.git\n",
+    "    cd lakeFS-hooks\n",
+    "    ```\n",
+    "    \n",
+    "2. Run the webhook server and attach it to the lakeFS network    \n",
+    "\n",
+    "    ```bash\n",
+    "    docker build -t lakefs-hooks .\n",
+    "    \n",
+    "    docker run --rm \\\n",
+    "               --network=bagel \\\n",
+    "               -e LAKEFS_SERVER_ADDRESS=http://lakefs:8000 \\\n",
+    "               -e LAKEFS_ACCESS_KEY_ID=AKIAIOSFOLKFSSAMPLES \\\n",
+    "               -e LAKEFS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \\\n",
+    "               --name lakefs-hooks\n",
+    "               lakefs-hooks\n",
+    "    ```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "045b0f59",
    "metadata": {},
    "source": [
@@ -32,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "8beda647",
    "metadata": {
     "tags": []
@@ -54,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "e0e31b83",
    "metadata": {
     "tags": []
@@ -84,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "cc0fe6a5",
    "metadata": {
     "tags": []
@@ -104,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "7bdd6c33",
    "metadata": {
     "tags": []
@@ -134,23 +167,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "21410385",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Verifying lakeFS credentials…\n",
-      "…✅lakeFS credentials verified\n",
-      "\n",
-      "ℹ️lakeFS version0.104.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Verifying lakeFS credentials…\")\n",
     "try:\n",
@@ -171,21 +193,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "b0b1cd2f",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Repository hooks-demo-01 does not exist, so going to try and create it now.\n",
-      "Created new repo hooks-demo-01 using storage namespace s3://example/hooks-demo-01\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from lakefs_client.exceptions import NotFoundException\n",
     "\n",
@@ -216,46 +229,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "a3cd47e5",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <div>\n",
-       "                <p><b>SparkSession - in-memory</b></p>\n",
-       "                \n",
-       "        <div>\n",
-       "            <p><b>SparkContext</b></p>\n",
-       "\n",
-       "            <p><a href=\"http://eba7a9ebda2f:4046\">Spark UI</a></p>\n",
-       "\n",
-       "            <dl>\n",
-       "              <dt>Version</dt>\n",
-       "                <dd><code>v3.3.2</code></dd>\n",
-       "              <dt>Master</dt>\n",
-       "                <dd><code>local[*]</code></dd>\n",
-       "              <dt>AppName</dt>\n",
-       "                <dd><code>lakeFS / Jupyter</code></dd>\n",
-       "            </dl>\n",
-       "        </div>\n",
-       "        \n",
-       "            </div>\n",
-       "        "
-      ],
-      "text/plain": [
-       "<pyspark.sql.session.SparkSession at 0x7f0bd95e55d0>"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
     "spark = SparkSession.builder.appName(\"lakeFS / Jupyter\") \\\n",
@@ -272,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "550604ab",
    "metadata": {
     "tags": []
@@ -286,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "ae76f5fe",
    "metadata": {
     "tags": []
@@ -322,51 +301,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "651c7e2b",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'pagination': {'has_more': False,\n",
-       "                'max_per_page': 1000,\n",
-       "                'next_offset': '',\n",
-       "                'results': 1},\n",
-       " 'results': [{'commit_id': '12d0159dfe4602c890b466b53374d7b5243a7a5547c8d823cd6a7a30c5c82176',\n",
-       "              'id': 'main'}]}"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "lakefs.branches.list_branches(repo_name)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "ac2681e8",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'12d0159dfe4602c890b466b53374d7b5243a7a5547c8d823cd6a7a30c5c82176'"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "lakefs.branches.create_branch(repository=repo_name, \n",
     "                              branch_creation=BranchCreation(name=ingest_branch, \n",
@@ -376,23 +328,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "30ee13a2",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'12d0159dfe4602c890b466b53374d7b5243a7a5547c8d823cd6a7a30c5c82176'"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "lakefs.branches.create_branch(repository=repo_name, \n",
     "                              branch_creation=BranchCreation(name=staging_branch, \n",
@@ -402,32 +343,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "4eda20a1",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'pagination': {'has_more': False,\n",
-       "                'max_per_page': 1000,\n",
-       "                'next_offset': '',\n",
-       "                'results': 3},\n",
-       " 'results': [{'commit_id': '12d0159dfe4602c890b466b53374d7b5243a7a5547c8d823cd6a7a30c5c82176',\n",
-       "              'id': 'ingest-landing-area'},\n",
-       "             {'commit_id': '12d0159dfe4602c890b466b53374d7b5243a7a5547c8d823cd6a7a30c5c82176',\n",
-       "              'id': 'main'},\n",
-       "             {'commit_id': '12d0159dfe4602c890b466b53374d7b5243a7a5547c8d823cd6a7a30c5c82176',\n",
-       "              'id': 'staging-area'}]}"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "lakefs.branches.list_branches(repo_name)\n"
    ]
@@ -442,23 +363,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "897649d2",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'dt=2023-07-17/movies.csv'"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ingest_data = \"movies.csv\"\n",
     "\n",
@@ -468,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "9b87b305",
    "metadata": {
     "tags": []
@@ -485,26 +395,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "3cd829e3",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[{'path': 'dt=2023-07-17/movies.csv',\n",
-       "  'path_type': 'object',\n",
-       "  'size_bytes': 1071619,\n",
-       "  'type': 'added'}]"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "lakefs.branches.diff_branch(repository=repo_name, \n",
     "                            branch=ingest_branch).results\n"
@@ -512,29 +408,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "b96c0e30",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'committer': 'everything-bagel',\n",
-       " 'creation_date': 1689579977,\n",
-       " 'id': '38ffd4c01f2b0be5329135a10fb9dcba54dca28d47eac1164c5068c2b55390c8',\n",
-       " 'message': \"netflix movie data arrived at landing area (today's partition)\",\n",
-       " 'meta_range_id': '',\n",
-       " 'metadata': {},\n",
-       " 'parents': ['12d0159dfe4602c890b466b53374d7b5243a7a5547c8d823cd6a7a30c5c82176']}"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "lakefs.commits.commit(repository=repo_name,\n",
     "                      branch=ingest_branch,\n",
@@ -558,7 +437,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "106d2b0d",
    "metadata": {
     "tags": []
@@ -571,7 +450,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "00f22bfe",
    "metadata": {
     "tags": []
@@ -588,26 +467,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "09b677a0",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[{'path': '_lakefs_actions/actions.yaml',\n",
-       "  'path_type': 'object',\n",
-       "  'size_bytes': 420,\n",
-       "  'type': 'added'}]"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "lakefs.branches.diff_branch(repository=repo_name, \n",
     "                            branch=staging_branch).results\n"
@@ -615,29 +480,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "e06aed40",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'committer': 'everything-bagel',\n",
-       " 'creation_date': 1689579978,\n",
-       " 'id': 'efd25c6c816d6aa20dcd8afee361fa104050fb4da1598eac14f595ccc491e5d3',\n",
-       " 'message': 'Added hooks config file - actions.yaml to staging area',\n",
-       " 'meta_range_id': '',\n",
-       " 'metadata': {},\n",
-       " 'parents': ['12d0159dfe4602c890b466b53374d7b5243a7a5547c8d823cd6a7a30c5c82176']}"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "lakefs.commits.commit(repository=repo_name,\n",
     "                      branch=staging_branch,\n",
@@ -656,23 +504,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "41981c11",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'s3a://hooks-demo-01/ingest-landing-area/dt=2023-07-17/movies.csv'"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ingest_long_path = f\"s3a://{repo_name}/{ingest_branch}/{ingest_path}\"\n",
     "ingest_long_path\n"
@@ -680,33 +517,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "4dad4a7b",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8791\n",
-      "root\n",
-      " |-- show_id: string (nullable = true)\n",
-      " |-- type: string (nullable = true)\n",
-      " |-- title: string (nullable = true)\n",
-      " |-- director: string (nullable = true)\n",
-      " |-- country: string (nullable = true)\n",
-      " |-- date_added: string (nullable = true)\n",
-      " |-- release_year: string (nullable = true)\n",
-      " |-- rating: string (nullable = true)\n",
-      " |-- duration: string (nullable = true)\n",
-      " |-- listed_in: string (nullable = true)\n",
-      "\n",
-      "None\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "movies_df = spark.read.option(\"header\",\"true\").csv(ingest_long_path)\n",
     "print(movies_df.count())\n",
@@ -715,42 +531,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "65193a7c",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+-------+-------+--------------------+-------------------+--------------+----------+------------+------+---------+--------------------+\n",
-      "|show_id|   type|               title|           director|       country|date_added|release_year|rating| duration|           listed_in|\n",
-      "+-------+-------+--------------------+-------------------+--------------+----------+------------+------+---------+--------------------+\n",
-      "|     s1|  Movie|Dick Johnson Is Dead|    Kirsten Johnson| United States| 9/25/2021|        2020| PG-13|   90 min|       Documentaries|\n",
-      "|     s3|TV Show|           Ganglands|    Julien Leclercq|        France| 9/24/2021|        2021| TV-MA| 1 Season|Crime TV Shows, I...|\n",
-      "|     s6|TV Show|       Midnight Mass|      Mike Flanagan| United States| 9/24/2021|        2021| TV-MA| 1 Season|TV Dramas, TV Hor...|\n",
-      "|    s14|  Movie|Confessions of an...|      Bruno Garotti|        Brazil| 9/22/2021|        2021| TV-PG|   91 min|Children & Family...|\n",
-      "|     s8|  Movie|             Sankofa|       Haile Gerima| United States| 9/24/2021|        1993| TV-MA|  125 min|Dramas, Independe...|\n",
-      "|     s9|TV Show|The Great British...|    Andy Devonshire|United Kingdom| 9/24/2021|        2021| TV-14|9 Seasons|British TV Shows,...|\n",
-      "|    s10|  Movie|        The Starling|     Theodore Melfi| United States| 9/24/2021|        2021| PG-13|  104 min|    Comedies, Dramas|\n",
-      "|   s939|  Movie|Motu Patlu in the...|        Suhas Kadav|         India|  5/1/2021|        2019| TV-Y7|   87 min|Children & Family...|\n",
-      "|    s13|  Movie|        Je Suis Karl|Christian Schwochow|       Germany| 9/23/2021|        2021| TV-MA|  127 min|Dramas, Internati...|\n",
-      "|   s940|  Movie|Motu Patlu in Won...|        Suhas Kadav|         India|  5/1/2021|        2013| TV-Y7|   76 min|Children & Family...|\n",
-      "+-------+-------+--------------------+-------------------+--------------+----------+------------+------+---------+--------------------+\n",
-      "only showing top 10 rows\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "movies_df.show(10)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "554e1a2e",
    "metadata": {
     "tags": []
@@ -770,23 +563,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "4cee0af8",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'s3a://hooks-demo-01/staging-area'"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "staging_long_path = f\"s3a://{repo_name}/{staging_branch}\"\n",
     "staging_long_path\n"
@@ -810,7 +592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "ce5577b8",
    "metadata": {
     "tags": []
@@ -825,29 +607,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "babad0a0",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'committer': 'everything-bagel',\n",
-       " 'creation_date': 1689580015,\n",
-       " 'id': 'f545bddbb91832c2ec2f11a4f98bc14ef539aec39bd9db31a5334f25f6dda544',\n",
-       " 'message': 'loaded paritioned movies parquet to staging area',\n",
-       " 'meta_range_id': '',\n",
-       " 'metadata': {},\n",
-       " 'parents': ['efd25c6c816d6aa20dcd8afee361fa104050fb4da1598eac14f595ccc491e5d3']}"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "lakefs.commits.commit(repository=repo_name,\n",
     "                      branch=staging_branch,\n",
@@ -865,23 +630,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "831a051f",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'reference': '6637b8c64326cfc8fba848cb5da243aced82721a0191621025e53841fd418a97'}"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "lakefs.refs.merge_into_branch(repository=repo_name, \n",
     "                              source_ref=staging_branch, \n",
@@ -906,7 +660,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "79b8cab4",
    "metadata": {
     "tags": []
@@ -922,29 +676,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "dfbc736c",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'committer': 'everything-bagel',\n",
-       " 'creation_date': 1689580019,\n",
-       " 'id': 'af391b975a6c92732ff6ba7210729c6eec2bc4bf66c8509ec9847f8fbd8490a7',\n",
-       " 'message': 'loaded paritioned movies csv to staging area',\n",
-       " 'meta_range_id': '',\n",
-       " 'metadata': {},\n",
-       " 'parents': ['f545bddbb91832c2ec2f11a4f98bc14ef539aec39bd9db31a5334f25f6dda544']}"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "lakefs.commits.commit(repository=repo_name,\n",
     "                      branch=staging_branch,\n",
@@ -962,32 +699,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "a70f5c0e",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "ename": "ApiException",
-     "evalue": "(412)\nReason: Precondition Failed\nHTTP response headers: HTTPHeaderDict({'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'X-Request-Id': 'e5d20b2f-217f-4836-bd58-c84b6196f1a8', 'Date': 'Mon, 17 Jul 2023 07:46:59 GMT', 'Content-Length': '261'})\nHTTP response body: {\"message\":\"update branch main: pre-merge hook aborted, run id '5hvqk3a2tk3c76sjukh0': 1 error occurred:\\n\\t* hook run id '0000_0000' failed on action 'ParquetOnlyInProduction' hook 'production_format_validator': webhook request failed (status code: 400)\\n\\n\"}\n\n",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mApiException\u001b[0m                              Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[32], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mlakefs\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrefs\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmerge_into_branch\u001b[49m\u001b[43m(\u001b[49m\u001b[43mrepository\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrepo_name\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[1;32m      2\u001b[0m \u001b[43m                              \u001b[49m\u001b[43msource_ref\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mstaging_branch\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[1;32m      3\u001b[0m \u001b[43m                              \u001b[49m\u001b[43mdestination_branch\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mprod_branch\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/opt/conda/lib/python3.10/site-packages/lakefs_client/api/refs_api.py:869\u001b[0m, in \u001b[0;36mRefsApi.merge_into_branch\u001b[0;34m(self, repository, source_ref, destination_branch, **kwargs)\u001b[0m\n\u001b[1;32m    865\u001b[0m kwargs[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124msource_ref\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m=\u001b[39m \\\n\u001b[1;32m    866\u001b[0m     source_ref\n\u001b[1;32m    867\u001b[0m kwargs[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mdestination_branch\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m=\u001b[39m \\\n\u001b[1;32m    868\u001b[0m     destination_branch\n\u001b[0;32m--> 869\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmerge_into_branch_endpoint\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcall_with_http_info\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/opt/conda/lib/python3.10/site-packages/lakefs_client/api_client.py:835\u001b[0m, in \u001b[0;36mEndpoint.call_with_http_info\u001b[0;34m(self, **kwargs)\u001b[0m\n\u001b[1;32m    831\u001b[0m         header_list \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mapi_client\u001b[38;5;241m.\u001b[39mselect_header_content_type(\n\u001b[1;32m    832\u001b[0m             content_type_headers_list)\n\u001b[1;32m    833\u001b[0m         params[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mheader\u001b[39m\u001b[38;5;124m'\u001b[39m][\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mContent-Type\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m=\u001b[39m header_list\n\u001b[0;32m--> 835\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mapi_client\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcall_api\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    836\u001b[0m \u001b[43m    \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msettings\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mendpoint_path\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msettings\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mhttp_method\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    837\u001b[0m \u001b[43m    \u001b[49m\u001b[43mparams\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mpath\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    838\u001b[0m \u001b[43m    \u001b[49m\u001b[43mparams\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mquery\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    839\u001b[0m \u001b[43m    \u001b[49m\u001b[43mparams\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mheader\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    840\u001b[0m \u001b[43m    \u001b[49m\u001b[43mbody\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mparams\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mbody\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    841\u001b[0m \u001b[43m    \u001b[49m\u001b[43mpost_params\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mparams\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mform\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    842\u001b[0m \u001b[43m    \u001b[49m\u001b[43mfiles\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mparams\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mfile\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    843\u001b[0m \u001b[43m    \u001b[49m\u001b[43mresponse_type\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msettings\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mresponse_type\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    844\u001b[0m \u001b[43m    \u001b[49m\u001b[43mauth_settings\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msettings\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mauth\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    845\u001b[0m \u001b[43m    \u001b[49m\u001b[43masync_req\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43masync_req\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    846\u001b[0m \u001b[43m    \u001b[49m\u001b[43m_check_type\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m_check_return_type\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    847\u001b[0m \u001b[43m    \u001b[49m\u001b[43m_return_http_data_only\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m_return_http_data_only\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    848\u001b[0m \u001b[43m    \u001b[49m\u001b[43m_preload_content\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m_preload_content\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    849\u001b[0m \u001b[43m    \u001b[49m\u001b[43m_request_timeout\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m_request_timeout\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    850\u001b[0m \u001b[43m    \u001b[49m\u001b[43m_host\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m_host\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    851\u001b[0m \u001b[43m    \u001b[49m\u001b[43mcollection_formats\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mparams\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mcollection_format\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/opt/conda/lib/python3.10/site-packages/lakefs_client/api_client.py:409\u001b[0m, in \u001b[0;36mApiClient.call_api\u001b[0;34m(self, resource_path, method, path_params, query_params, header_params, body, post_params, files, response_type, auth_settings, async_req, _return_http_data_only, collection_formats, _preload_content, _request_timeout, _host, _check_type)\u001b[0m\n\u001b[1;32m    355\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"Makes the HTTP request (synchronous) and returns deserialized data.\u001b[39;00m\n\u001b[1;32m    356\u001b[0m \n\u001b[1;32m    357\u001b[0m \u001b[38;5;124;03mTo make an async_req request, set the async_req parameter.\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    406\u001b[0m \u001b[38;5;124;03m    then the method will return the response directly.\u001b[39;00m\n\u001b[1;32m    407\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    408\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m async_req:\n\u001b[0;32m--> 409\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m__call_api\u001b[49m\u001b[43m(\u001b[49m\u001b[43mresource_path\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmethod\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    410\u001b[0m \u001b[43m                           \u001b[49m\u001b[43mpath_params\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mquery_params\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mheader_params\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    411\u001b[0m \u001b[43m                           \u001b[49m\u001b[43mbody\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpost_params\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfiles\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    412\u001b[0m \u001b[43m                           \u001b[49m\u001b[43mresponse_type\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mauth_settings\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    413\u001b[0m \u001b[43m                           \u001b[49m\u001b[43m_return_http_data_only\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcollection_formats\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    414\u001b[0m \u001b[43m                           \u001b[49m\u001b[43m_preload_content\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m_request_timeout\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m_host\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    415\u001b[0m \u001b[43m                           \u001b[49m\u001b[43m_check_type\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    417\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpool\u001b[38;5;241m.\u001b[39mapply_async(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m__call_api, (resource_path,\n\u001b[1;32m    418\u001b[0m                                                method, path_params,\n\u001b[1;32m    419\u001b[0m                                                query_params,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    427\u001b[0m                                                _request_timeout,\n\u001b[1;32m    428\u001b[0m                                                _host, _check_type))\n",
-      "File \u001b[0;32m/opt/conda/lib/python3.10/site-packages/lakefs_client/api_client.py:203\u001b[0m, in \u001b[0;36mApiClient.__call_api\u001b[0;34m(self, resource_path, method, path_params, query_params, header_params, body, post_params, files, response_type, auth_settings, _return_http_data_only, collection_formats, _preload_content, _request_timeout, _host, _check_type)\u001b[0m\n\u001b[1;32m    201\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m ApiException \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m    202\u001b[0m     e\u001b[38;5;241m.\u001b[39mbody \u001b[38;5;241m=\u001b[39m e\u001b[38;5;241m.\u001b[39mbody\u001b[38;5;241m.\u001b[39mdecode(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mutf-8\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[0;32m--> 203\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m e\n\u001b[1;32m    205\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mlast_response \u001b[38;5;241m=\u001b[39m response_data\n\u001b[1;32m    207\u001b[0m return_data \u001b[38;5;241m=\u001b[39m response_data\n",
-      "File \u001b[0;32m/opt/conda/lib/python3.10/site-packages/lakefs_client/api_client.py:196\u001b[0m, in \u001b[0;36mApiClient.__call_api\u001b[0;34m(self, resource_path, method, path_params, query_params, header_params, body, post_params, files, response_type, auth_settings, _return_http_data_only, collection_formats, _preload_content, _request_timeout, _host, _check_type)\u001b[0m\n\u001b[1;32m    192\u001b[0m     url \u001b[38;5;241m=\u001b[39m _host \u001b[38;5;241m+\u001b[39m resource_path\n\u001b[1;32m    194\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[1;32m    195\u001b[0m     \u001b[38;5;66;03m# perform request and return response\u001b[39;00m\n\u001b[0;32m--> 196\u001b[0m     response_data \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrequest\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    197\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmethod\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43murl\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mquery_params\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mquery_params\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mheaders\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mheader_params\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    198\u001b[0m \u001b[43m        \u001b[49m\u001b[43mpost_params\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mpost_params\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mbody\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbody\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    199\u001b[0m \u001b[43m        \u001b[49m\u001b[43m_preload_content\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m_preload_content\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    200\u001b[0m \u001b[43m        \u001b[49m\u001b[43m_request_timeout\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m_request_timeout\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    201\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m ApiException \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m    202\u001b[0m     e\u001b[38;5;241m.\u001b[39mbody \u001b[38;5;241m=\u001b[39m e\u001b[38;5;241m.\u001b[39mbody\u001b[38;5;241m.\u001b[39mdecode(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mutf-8\u001b[39m\u001b[38;5;124m'\u001b[39m)\n",
-      "File \u001b[0;32m/opt/conda/lib/python3.10/site-packages/lakefs_client/api_client.py:455\u001b[0m, in \u001b[0;36mApiClient.request\u001b[0;34m(self, method, url, query_params, headers, post_params, body, _preload_content, _request_timeout)\u001b[0m\n\u001b[1;32m    447\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mrest_client\u001b[38;5;241m.\u001b[39mOPTIONS(url,\n\u001b[1;32m    448\u001b[0m                                     query_params\u001b[38;5;241m=\u001b[39mquery_params,\n\u001b[1;32m    449\u001b[0m                                     headers\u001b[38;5;241m=\u001b[39mheaders,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    452\u001b[0m                                     _request_timeout\u001b[38;5;241m=\u001b[39m_request_timeout,\n\u001b[1;32m    453\u001b[0m                                     body\u001b[38;5;241m=\u001b[39mbody)\n\u001b[1;32m    454\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m method \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mPOST\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m--> 455\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrest_client\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mPOST\u001b[49m\u001b[43m(\u001b[49m\u001b[43murl\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    456\u001b[0m \u001b[43m                                 \u001b[49m\u001b[43mquery_params\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mquery_params\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    457\u001b[0m \u001b[43m                                 \u001b[49m\u001b[43mheaders\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mheaders\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    458\u001b[0m \u001b[43m                                 \u001b[49m\u001b[43mpost_params\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mpost_params\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    459\u001b[0m \u001b[43m                                 \u001b[49m\u001b[43m_preload_content\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m_preload_content\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    460\u001b[0m \u001b[43m                                 \u001b[49m\u001b[43m_request_timeout\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m_request_timeout\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    461\u001b[0m \u001b[43m                                 \u001b[49m\u001b[43mbody\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbody\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    462\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m method \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mPUT\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m    463\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mrest_client\u001b[38;5;241m.\u001b[39mPUT(url,\n\u001b[1;32m    464\u001b[0m                                 query_params\u001b[38;5;241m=\u001b[39mquery_params,\n\u001b[1;32m    465\u001b[0m                                 headers\u001b[38;5;241m=\u001b[39mheaders,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    468\u001b[0m                                 _request_timeout\u001b[38;5;241m=\u001b[39m_request_timeout,\n\u001b[1;32m    469\u001b[0m                                 body\u001b[38;5;241m=\u001b[39mbody)\n",
-      "File \u001b[0;32m/opt/conda/lib/python3.10/site-packages/lakefs_client/rest.py:267\u001b[0m, in \u001b[0;36mRESTClientObject.POST\u001b[0;34m(self, url, headers, query_params, post_params, body, _preload_content, _request_timeout)\u001b[0m\n\u001b[1;32m    265\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mPOST\u001b[39m(\u001b[38;5;28mself\u001b[39m, url, headers\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, query_params\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, post_params\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m    266\u001b[0m          body\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, _preload_content\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m, _request_timeout\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[0;32m--> 267\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrequest\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mPOST\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43murl\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    268\u001b[0m \u001b[43m                        \u001b[49m\u001b[43mheaders\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mheaders\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    269\u001b[0m \u001b[43m                        \u001b[49m\u001b[43mquery_params\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mquery_params\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    270\u001b[0m \u001b[43m                        \u001b[49m\u001b[43mpost_params\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mpost_params\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    271\u001b[0m \u001b[43m                        \u001b[49m\u001b[43m_preload_content\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m_preload_content\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    272\u001b[0m \u001b[43m                        \u001b[49m\u001b[43m_request_timeout\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m_request_timeout\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    273\u001b[0m \u001b[43m                        \u001b[49m\u001b[43mbody\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbody\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/opt/conda/lib/python3.10/site-packages/lakefs_client/rest.py:226\u001b[0m, in \u001b[0;36mRESTClientObject.request\u001b[0;34m(self, method, url, query_params, headers, body, post_params, _preload_content, _request_timeout)\u001b[0m\n\u001b[1;32m    223\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;241m500\u001b[39m \u001b[38;5;241m<\u001b[39m\u001b[38;5;241m=\u001b[39m r\u001b[38;5;241m.\u001b[39mstatus \u001b[38;5;241m<\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;241m599\u001b[39m:\n\u001b[1;32m    224\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m ServiceException(http_resp\u001b[38;5;241m=\u001b[39mr)\n\u001b[0;32m--> 226\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m ApiException(http_resp\u001b[38;5;241m=\u001b[39mr)\n\u001b[1;32m    228\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m r\n",
-      "\u001b[0;31mApiException\u001b[0m: (412)\nReason: Precondition Failed\nHTTP response headers: HTTPHeaderDict({'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'X-Request-Id': 'e5d20b2f-217f-4836-bd58-c84b6196f1a8', 'Date': 'Mon, 17 Jul 2023 07:46:59 GMT', 'Content-Length': '261'})\nHTTP response body: {\"message\":\"update branch main: pre-merge hook aborted, run id '5hvqk3a2tk3c76sjukh0': 1 error occurred:\\n\\t* hook run id '0000_0000' failed on action 'ParquetOnlyInProduction' hook 'production_format_validator': webhook request failed (status code: 400)\\n\\n\"}\n\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "lakefs.refs.merge_into_branch(repository=repo_name, \n",
     "                              source_ref=staging_branch, \n",

--- a/README.md
+++ b/README.md
@@ -42,10 +42,6 @@ docker compose down
 If you want to provision a lakeFS server as well as MinIO for your object store, plus Jupyter then bring up the full stack:
 
 ```bash
-# make sure we have got the lakeFS hooks content too
-git submodule init
-git submodule update
-
 docker compose up
 ```
 
@@ -57,7 +53,6 @@ As above, open the Jupyter Notebook (http://localhost:8888) peruse the [catalog 
 * **Jupyter Notebook** is based on the [Jupyter PySpark notebook](https://hub.docker.com/r/jupyter/pyspark-notebook/) and provides an interactive environment in which to explore lakeFS using Python and PySpark. 
 * **lakeFS** can be provisioned as part of this environment, or provided by [lakeFS cloud](http://https://lakefs.cloud/) or your [own installation](https://docs.lakefs.io/deploy/).
 * If you run lakeFS as part of this environment, **MinIO** is provided as an S3-compatible object store. If you run lakeFS yourself you can use other S3-compatible object stores include S3, GCS, as well as MinIO
-* A sample **lakeFS webhooks server** is provided, configured based on using the provided lakeFS server. 
 
 ### Containers
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,16 +87,6 @@ services:
       - ./00_notebooks:/home/jovyan/notebooks
       - ./data:/data
 
-  lakefs-webhooks:
-    build: lakeFS-hooks
-    image: lakefs-hooks
-    depends_on:
-      - lakefs
-    environment:
-      - LAKEFS_SERVER_ADDRESS=http://lakefs:8000
-      - LAKEFS_ACCESS_KEY_ID=AKIAIOSFOLKFSSAMPLES
-      - LAKEFS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-
 networks:
   default:
     name: bagel


### PR DESCRIPTION
See #119 for background. 

Webhooks example is still available, just with instructions moved into the notebook to simplify the Docker Compose for everyone else. 