### PR TITLE
Don't change the port number for Airflow UI

### DIFF
--- a/01_standalone_examples/airflow-01/README.md
+++ b/01_standalone_examples/airflow-01/README.md
@@ -37,7 +37,7 @@ This repository includes following Jupyter Notebooks which you can run on your l
    ```bash
       docker build -t lakefs-airflow-integration-demo .
 
-      docker run -d -p 18888:8888 -p 14040:4040 -p 18080:8080 --user root -e GRANT_SUDO=yes -v $PWD:/home/jovyan -v $PWD/jupyter_notebook_config.py:/home/jovyan/.jupyter/jupyter_notebook_config.py --name lakefs-airflow-integration-demo lakefs-airflow-integration-demo
+      docker run -d -p 18888:8888 -p 14040:4040 -p 8080:8080 --user root -e GRANT_SUDO=yes -v $PWD:/home/jovyan -v $PWD/jupyter_notebook_config.py:/home/jovyan/.jupyter/jupyter_notebook_config.py --name lakefs-airflow-integration-demo lakefs-airflow-integration-demo
    ```
 
 3. Open JupyterLab UI [http://127.0.0.1:18888/](http://127.0.0.1:18888/) in your web browser.


### PR DESCRIPTION
Don't change the port number for Airflow UI otherwise I will have to change all Airflow demo notebooks (4 in total) to use different port number.