### PR TITLE
Fix notebook delta-lake-python.ipynb

### DIFF
--- a/00_notebooks/delta-lake-python.ipynb
+++ b/00_notebooks/delta-lake-python.ipynb
@@ -226,7 +226,7 @@
     "                   \"AWS_SECRET_ACCESS_KEY\":lakefsSecretKey,\n",
     "                   \"AWS_ENDPOINT\": lakefsEndPoint,\n",
     "                   \"AWS_REGION\": \"us-east-1\",\n",
-    "                   \"AWS_STORAGE_ALLOW_HTTP\": \"true\",\n",
+    "                   \"AWS_ALLOW_HTTP\": \"true\",\n",
     "                   \"AWS_S3_ALLOW_UNSAFE_RENAME\": \"true\"\n",
     "                  }"
    ]


### PR DESCRIPTION
From Deltalake version 0.11.0, the env variable must be changed to AWS_ALLOW_HTTP from AWS_STORAGE_ALLOW_HTTP