### PR TITLE
URL comment - no trailing slash

### DIFF
--- a/00_notebooks/delta-diff.ipynb
+++ b/00_notebooks/delta-diff.ipynb
@@ -41,7 +41,7 @@
    },
    "outputs": [],
    "source": [
-    "lakefsEndPoint = 'http://lakefs:8000' # e.g. 'https://username.aws_region_name.lakefscloud.io' \n",
+    "lakefsEndPoint = 'http://lakefs:8000' # e.g. 'https://username.aws_region_name.lakefscloud.io' - Note: The URL should NOT end with a trailing slash \n",
     "lakefsAccessKey = 'AKIAIOSFOLKFSSAMPLES'\n",
     "lakefsSecretKey = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'"
    ]

--- a/00_notebooks/delta-lake-python.ipynb
+++ b/00_notebooks/delta-lake-python.ipynb
@@ -43,7 +43,7 @@
    },
    "outputs": [],
    "source": [
-    "lakefsEndPoint = 'http://lakefs:8000' # e.g. 'https://username.aws_region_name.lakefscloud.io' \n",
+    "lakefsEndPoint = 'http://lakefs:8000' # e.g. 'https://username.aws_region_name.lakefscloud.io' - Note: The URL should NOT end with a trailing slash \n",
     "lakefsAccessKey = 'AKIAIOSFOLKFSSAMPLES'\n",
     "lakefsSecretKey = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'"
    ]

--- a/00_notebooks/delta-lake.ipynb
+++ b/00_notebooks/delta-lake.ipynb
@@ -54,7 +54,7 @@
    },
    "outputs": [],
    "source": [
-    "lakefsEndPoint = 'http://lakefs:8000' # e.g. 'https://username.aws_region_name.lakefscloud.io' - Note: URL shouldn't end with a trailing slash \n",
+    "lakefsEndPoint = 'http://lakefs:8000' # e.g. 'https://username.aws_region_name.lakefscloud.io' - Note: The URL should NOT end with a trailing slash \n",
     "lakefsAccessKey = 'AKIAIOSFOLKFSSAMPLES'\n",
     "lakefsSecretKey = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'"
    ]

--- a/00_notebooks/delta-lake.ipynb
+++ b/00_notebooks/delta-lake.ipynb
@@ -54,7 +54,7 @@
    },
    "outputs": [],
    "source": [
-    "lakefsEndPoint = 'http://lakefs:8000' # e.g. 'https://username.aws_region_name.lakefscloud.io' \n",
+    "lakefsEndPoint = 'http://lakefs:8000' # e.g. 'https://username.aws_region_name.lakefscloud.io' - Note: URL shouldn't end with a trailing slash \n",
     "lakefsAccessKey = 'AKIAIOSFOLKFSSAMPLES'\n",
     "lakefsSecretKey = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'"
    ]


### PR DESCRIPTION
Due to a Delta Lake package bug (mis-formatting of a URL), if the given lakeFS URL is ending with a trailing slash, the code will fail to work.
There's nothing we can do about it other than mentioning it (and possibly contributing to their code), but some users failed because of that.