### PR TITLE
lakeFS Enterprise Sample: Changed tag for Fluffy container to latest

### DIFF
--- a/02_lakefs_enterprise/docker-compose.yml
+++ b/02_lakefs_enterprise/docker-compose.yml
@@ -107,7 +107,7 @@ services:
       start_period: 5s
 
   fluffy:
-    image: "${FLUFFY_REPO:-treeverse}/fluffy:${TAG:-0.4.0}"
+    image: "${FLUFFY_REPO:-treeverse}/fluffy:${TAG:-latest}"
     command: "${COMMAND:-run}"
     ports:
       - "8085:8000"


### PR DESCRIPTION
Old tag for Fluffy container doesn't work with latest lakeFS container. So, changed tag for Fluffy container to latest.