### PR TITLE
Add E2B + lakeFS agentic-data-PR example

### DIFF
--- a/01_standalone_examples/e2b/.gitignore
+++ b/01_standalone_examples/e2b/.gitignore
@@ -1,0 +1,22 @@
+.env
+*.env
+# editor swap files (vim) — may contain secret fragments
+*.swp
+*.swo
+*.swn
+.*.sw[a-p]
+**/outputs/*.json
+**/outputs/*.csv
+**/outputs/*.md
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.venv/
+*.egg-info/
+dist/
+build/
+.DS_Store
+
+# everest enterprise binary copied into the template build context (not redistributable)
+usecases/03-mount-receipts/template/everest

--- a/01_standalone_examples/e2b/README.md
+++ b/01_standalone_examples/e2b/README.md
@@ -80,10 +80,3 @@ cat usecases/02-three-phase-repair/README.md
 
 Each use case reads its own `.env` (copy from the local `.env.example`). Secrets
 are never committed — `.env` files are gitignored.
-
----
-
-## History
-
-Use cases 1 and 2 previously lived on separate branches (`main` and `demo-v2`).
-Those branches are preserved for reference; this monorepo layout supersedes them.

--- a/01_standalone_examples/e2b/README.md
+++ b/01_standalone_examples/e2b/README.md
@@ -1,0 +1,89 @@
+# Agentic Data Patterns: E2B + lakeFS
+
+> A collection of self-contained demos showing the same core idea from different
+> angles: **an AI agent executes in an isolated E2B sandbox and versions its work
+> in lakeFS** — every iteration committed, nothing reaching `main` until it passes
+> a server-enforced gate.
+
+E2B gives the agent **compute isolation** (generated code can't touch your network
+or infra). lakeFS gives it **data isolation and version control** (each run gets
+its own branch; intermediate and failed states never touch production; a pre-merge
+Action enforces promotion rules regardless of who triggers the merge).
+
+---
+
+## Prerequisites
+
+All use cases need an E2B account and a lakeFS instance:
+
+- **E2B** — sign up at [e2b.dev](https://e2b.dev) and grab your API key from the
+  [dashboard](https://e2b.dev/dashboard).
+- **lakeFS** — the easiest path is [lakeFS Cloud](https://lakefs.cloud/) (free sign-up);
+  a self-hosted instance reachable from the internet works too. **Use case 3 additionally
+  requires lakeFS Mount (`everest`)**, which is available on lakeFS Cloud / Enterprise.
+- **OpenAI** — use cases 2 and 3 call an OpenAI model (`OPENAI_API_KEY`).
+
+Each use case has its own `.env.example` listing exactly what it needs.
+
+---
+
+## Use cases
+
+| # | Directory | Pattern | Data path |
+|---|-----------|---------|-----------|
+| 1 | [`usecases/01-sdk-orchestrator`](usecases/01-sdk-orchestrator) | Orchestrated agent job: isolated compute + isolated data branch | lakeFS **Python SDK** |
+| 2 | [`usecases/02-three-phase-repair`](usecases/02-three-phase-repair) | Iterative LLM data repair through three progressive validation phases | lakeFS **Python SDK** |
+| 3 | [`usecases/03-mount-receipts`](usecases/03-mount-receipts) | Multimodal receipt → ledger curation; agent works on a mounted filesystem | lakeFS **Mount (`everest`)** |
+
+**SDK vs Mount.** Use cases 1–2 move data via the lakeFS SDK (read object →
+process → write object → commit). Use case 3 uses **lakeFS Mount**, exposing the
+branch as a real filesystem — so the agent does plain file I/O (`open`, `glob`,
+`write`) with no SDK or S3 knowledge, which is how most agents naturally operate.
+Versioning happens via `everest commit`. Demo 3 needs a lakeFS instance with
+Mount (`everest`) enabled.
+
+---
+
+## Layout
+
+```
+.
+├── shared/lakefs_e2b_common/   # shared plumbing: lakeFS SDK wrappers + env loading
+├── usecases/
+│   ├── 01-sdk-orchestrator/    # use case 1  (package: lakefs_e2b_poc)
+│   ├── 02-three-phase-repair/  # use case 2  (package: agent_demo)
+│   └── 03-mount-receipts/      # use case 3  (package: mount_receipts)
+├── pyproject.toml              # uv workspace root (members: shared + usecases/*)
+└── README.md
+```
+
+This is a **uv workspace**: one `.venv` shared across all members, each installed
+editable. The shared package (`lakefs_e2b_common`) holds the lakeFS SDK wrappers
+and env-loading helpers; use-case-specific logic (validation rules, agent loops,
+sandbox runners, reporting) lives inside each use case.
+
+> Use case 2 imports the shared plumbing. Use case 1 was relocated as-built
+> (self-contained) and can be migrated onto `lakefs_e2b_common` once it's been
+> re-run against a live lakeFS instance.
+
+---
+
+## Quickstart
+
+```bash
+# Install everything (shared + all use cases) into one .venv
+uv sync
+
+# Each use case has its own README, .env.example, and run instructions:
+cat usecases/02-three-phase-repair/README.md
+```
+
+Each use case reads its own `.env` (copy from the local `.env.example`). Secrets
+are never committed — `.env` files are gitignored.
+
+---
+
+## History
+
+Use cases 1 and 2 previously lived on separate branches (`main` and `demo-v2`).
+Those branches are preserved for reference; this monorepo layout supersedes them.

--- a/01_standalone_examples/e2b/pyproject.toml
+++ b/01_standalone_examples/e2b/pyproject.toml
@@ -1,0 +1,17 @@
+# Virtual workspace root for the lakeFS + E2B agentic demos.
+#
+# This repo hosts several self-contained use cases under usecases/, all sharing
+# the plumbing in shared/. `uv sync` from here installs every member (the shared
+# package + each use case) editable into one .venv.
+[tool.uv.workspace]
+members = ["shared", "usecases/*"]
+
+[tool.uv.sources]
+lakefs-e2b-common = { workspace = true }
+
+# Workspace-wide test run (`uv run pytest`). importlib mode lets the use cases each
+# keep a tests/test_validation.py without module-name collisions. Members are installed
+# editable, so no pythonpath wiring is needed.
+[tool.pytest.ini_options]
+addopts = "--import-mode=importlib"
+testpaths = ["usecases", "shared"]

--- a/01_standalone_examples/e2b/shared/lakefs_e2b_common/__init__.py
+++ b/01_standalone_examples/e2b/shared/lakefs_e2b_common/__init__.py
@@ -1,0 +1,16 @@
+"""Shared plumbing for the lakeFS + E2B agentic demos.
+
+This package holds the helpers that every use case builds on:
+
+- ``lakefs_client``: thin wrappers around the lakeFS high-level Python SDK
+  (create/read/write/commit/merge branches, install pre-merge Actions).
+- ``env``: small helpers for loading and requiring environment variables.
+
+Use-case-specific logic (validation rules, agent loops, sandbox runners,
+reporting) lives inside each ``usecases/<name>`` package, not here.
+"""
+from __future__ import annotations
+
+from lakefs_e2b_common import env, lakefs_client
+
+__all__ = ["env", "lakefs_client"]

--- a/01_standalone_examples/e2b/shared/lakefs_e2b_common/env.py
+++ b/01_standalone_examples/e2b/shared/lakefs_e2b_common/env.py
@@ -1,0 +1,38 @@
+"""Environment-variable loading helpers shared across use cases.
+
+Each use case defines its own typed ``Config`` dataclass, but they all read
+from the environment the same way: load a ``.env`` file if present, then pull
+required values (erroring clearly when one is missing) and optional values
+(with defaults). These helpers centralise that pattern.
+"""
+from __future__ import annotations
+
+import os
+
+from dotenv import find_dotenv, load_dotenv
+
+# Load a .env file searching from the current working directory upward. In the
+# monorepo each use case keeps its own .env in its own directory, so we must
+# discover relative to the cwd (where the script/command is run), NOT relative
+# to this shared module's location.
+load_dotenv(find_dotenv(usecwd=True))
+
+
+def require(name: str) -> str:
+    """Return a required environment variable, or exit with a clear message."""
+    val = os.environ.get(name, "").strip()
+    if not val:
+        raise SystemExit(f"ERROR: Required environment variable {name!r} is not set.")
+    return val
+
+
+def optional(name: str, default: str = "") -> str:
+    """Return an optional environment variable, falling back to ``default``."""
+    val = os.environ.get(name, "").strip()
+    return val or default
+
+
+def optional_int(name: str, default: int) -> int:
+    """Return an optional integer environment variable, falling back to ``default``."""
+    raw = os.environ.get(name, "").strip()
+    return int(raw) if raw else default

--- a/01_standalone_examples/e2b/shared/lakefs_e2b_common/lakefs_client.py
+++ b/01_standalone_examples/e2b/shared/lakefs_e2b_common/lakefs_client.py
@@ -1,0 +1,114 @@
+"""Thin wrappers around the lakeFS high-level Python SDK."""
+from __future__ import annotations
+
+import lakefs
+from lakefs.client import Client
+
+
+def make_client(endpoint: str, access_key_id: str, secret_access_key: str) -> Client:
+    """Create and return a lakeFS Client."""
+    return Client(host=endpoint, username=access_key_id, password=secret_access_key)
+
+
+def get_or_create_repo(
+    client: Client, repo_name: str, storage_namespace: str = ""
+) -> lakefs.Repository:
+    """Return the repository, creating it if it doesn't exist and storage_namespace is given."""
+    repo = lakefs.repository(repo_name, client=client)
+    try:
+        _ = list(repo.branches())
+        return repo
+    except Exception as exc:
+        err = str(exc).lower()
+        if "not found" in err or "404" in err or "no such repository" in err or "repository" in err:
+            if not storage_namespace:
+                raise SystemExit(
+                    f"ERROR: lakeFS repository '{repo_name}' does not exist.\n"
+                    "Either create it in the lakeFS UI or set LAKEFS_STORAGE_NAMESPACE "
+                    "to allow automatic creation.\n"
+                    "  Example: LAKEFS_STORAGE_NAMESPACE=s3://my-bucket/data-agent-demo/"
+                ) from exc
+            print(f"  Repository '{repo_name}' not found. Creating with namespace '{storage_namespace}'...")
+            return repo.create(storage_namespace=storage_namespace)
+        raise
+
+
+def create_branch(
+    repo: lakefs.Repository, branch_name: str, source_branch: str
+) -> lakefs.Branch:
+    """Create and return a new branch from source_branch."""
+    return repo.branch(branch_name).create(source_reference=source_branch)
+
+
+def read_object(branch: lakefs.Branch, path: str) -> str:
+    """Read an object from the branch and return its text content."""
+    obj = branch.object(path)
+    data = obj.reader().read()
+    if isinstance(data, bytes):
+        return data.decode("utf-8")
+    return data
+
+
+def write_object(branch: lakefs.Branch, path: str, content: str | bytes) -> None:
+    """Write content to an object on the branch."""
+    obj = branch.object(path)
+    if isinstance(content, str):
+        content = content.encode("utf-8")
+    with obj.writer() as w:
+        w.write(content)
+
+
+def commit(branch: lakefs.Branch, message: str, metadata: dict[str, str]) -> str:
+    """Commit staged changes and return the commit ID."""
+    result = branch.commit(message=message, metadata=metadata)
+    return result.get_commit().id
+
+
+def merge_branch(feature_branch: lakefs.Branch, main_branch_obj: lakefs.Branch) -> str:
+    """Merge feature_branch into main_branch_obj and return the merge ref."""
+    result = feature_branch.merge_into(main_branch_obj)
+    return str(result)
+
+
+def list_branches(repo: lakefs.Repository) -> list[str]:
+    """Return a list of branch names for the repository."""
+    return [b.id for b in repo.branches()]
+
+
+def list_commits(branch: lakefs.Branch, max_amount: int = 10) -> list[dict]:
+    """Return up to max_amount recent commits as dicts."""
+    commits = []
+    for c in branch.log(max_amount=max_amount):
+        commit_obj = c.get_commit() if hasattr(c, "get_commit") else c
+        commits.append(
+            {
+                "id": getattr(commit_obj, "id", str(c)),
+                "message": getattr(commit_obj, "message", ""),
+                "committer": getattr(commit_obj, "committer", ""),
+            }
+        )
+    return commits
+
+
+def upload_lakefsactions_yaml(
+    repo: lakefs.Repository,
+    yaml_content: str,
+    filename: str = "validate_data.yaml",
+) -> None:
+    """Upload a pre-merge action to ``_lakefs_actions/<filename>`` on main and commit.
+
+    Idempotent: if the action is already present unchanged, the commit is a no-op rather
+    than an error (so setup can be re-run safely).
+    """
+    main_branch = repo.branch("main")
+    write_object(main_branch, f"_lakefs_actions/{filename}", yaml_content)
+    try:
+        commit(
+            main_branch,
+            message=f"Add/update pre-merge action ({filename})",
+            metadata={"created_by": "setup_script"},
+        )
+    except Exception as exc:  # already installed & unchanged -> nothing to commit
+        if "no changes" in str(exc).lower():
+            return
+        raise

--- a/01_standalone_examples/e2b/shared/pyproject.toml
+++ b/01_standalone_examples/e2b/shared/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "lakefs-e2b-common"
+version = "0.1.0"
+description = "Shared lakeFS + E2B plumbing for the agentic demos (SDK client wrappers, env loading)"
+requires-python = ">=3.11"
+dependencies = [
+    "lakefs",
+    "python-dotenv>=1.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["lakefs_e2b_common"]

--- a/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/.env.example
+++ b/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/.env.example
@@ -1,0 +1,19 @@
+# Required
+E2B_API_KEY=your_e2b_api_key_here
+LAKEFS_ENDPOINT=https://your-org.lakefscloud.io
+LAKEFS_ACCESS_KEY_ID=your_lakefs_access_key
+LAKEFS_SECRET_ACCESS_KEY=your_lakefs_secret_key
+LAKEFS_REPO=orders-demo
+LAKEFS_MAIN_BRANCH=main
+
+# Optional — defaults to LAKEFS_ENDPOINT if not set
+# LAKEFS_S3_ENDPOINT=https://your-org.lakefscloud.io
+
+# Optional — only needed to auto-create the repo (e.g. s3://my-bucket/lakefs-data)
+# LAKEFS_STORAGE_NAMESPACE=s3://my-bucket/lakefs-data
+
+# Optional — set to "false" to delete branches after a successful merge + --cleanup
+# KEEP_BRANCHES=true
+
+# Optional — set to "true" only if you've set up a tunnel for local lakeFS
+# ALLOW_LOCALHOST_LAKEFS=false

--- a/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/README.md
+++ b/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/README.md
@@ -89,9 +89,9 @@ machine, not accessible from the cloud.
 ## Setup
 
 ```bash
-# 1. Clone the repo and install the uv workspace (from the repo root)
-git clone https://github.com/treeverse/lakefs-e2b-agentic-data-pr
-cd lakefs-e2b-agentic-data-pr
+# 1. Clone lakeFS-samples and install the uv workspace (from this example's root)
+git clone https://github.com/treeverse/lakeFS-samples
+cd lakeFS-samples/01_standalone_examples/e2b
 uv sync
 
 # 2. Enter this use case

--- a/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/README.md
+++ b/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/README.md
@@ -1,0 +1,280 @@
+# Use Case 1 — SDK Orchestrator
+
+> Part of [**Agentic Data Patterns: E2B + lakeFS**](../../README.md). See the repo root for the full set of use cases.
+
+A minimal Python POC demonstrating the **Agentic Data PR** pattern:
+
+> **E2B** provides isolated compute for agent-generated code.  
+> **lakeFS** provides isolated, versioned data branches for that code's side-effects.  
+>
+> The agent runs inside an E2B cloud sandbox, reads raw data from a lakeFS branch,
+> writes transformed outputs back to that same branch, and then — only if validation
+> passes — the **host** (your machine) commits and merges the branch into `main`.
+> Failed agent runs leave `main` untouched.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                   HOST  (your machine)                      │
+│                                                             │
+│   orchestrator.py                                           │
+│   ┌──────────────────────┐   ┌──────────────────────────┐  │
+│   │   lakeFS SDK         │   │   E2B SDK                │  │
+│   │                      │   │                          │  │
+│   │ 1. create branch     │   │ 4. start sandbox         │  │
+│   │ 2. (wait for agent)  │   │ 5. upload agent_job.py   │  │
+│   │ 3. list uncommitted  │   │ 6. pip install deps      │  │
+│   │ 7. commit branch     │   │    run agent_job.py      │  │
+│   │ 8. merge if pass     │   │                          │  │
+│   └──────────┬───────────┘   └─────────────┬────────────┘  │
+│              │                             │               │
+└──────────────┼─────────────────────────────┼───────────────┘
+               │                             │
+               ▼                             ▼
+      ┌────────────────┐           ┌──────────────────────┐
+      │    lakeFS      │◄──boto3───│  E2B Cloud Sandbox   │
+      │                │   S3 GW   │                      │
+      │ • branches     │           │  agent_job.py        │
+      │ • commits      │           │  • read  raw/orders  │
+      │ • objects      │           │  • clean & transform │
+      └────────────────┘           │  • write curated/    │
+                                   │  • write reports/    │
+                                   │  • print JSON result │
+                                   └──────────────────────┘
+```
+
+### Key isolation properties
+
+| Dimension | Isolation mechanism |
+|-----------|---------------------|
+| Compute   | E2B cloud sandbox — ephemeral, network-isolated from your machine |
+| Data      | lakeFS feature branch — zero-copy, completely isolated from `main` |
+| Secrets   | Agent sees only the env vars it needs; host never logs secret values |
+| Safety    | Only the host can commit/merge; agent only reads/writes objects |
+
+---
+
+## Why localhost lakeFS does not work from E2B
+
+E2B sandboxes run in E2B's cloud infrastructure.  
+A lakeFS endpoint on `localhost`, `127.0.0.1`, or `host.docker.internal` is your local
+machine, not accessible from the cloud.
+
+**Options:**
+1. **lakeFS Cloud** — the easiest path: sign up at [lakefs.cloud](https://lakefs.cloud/)
+2. **Tunnel** — expose your local lakeFS via [ngrok](https://ngrok.com),
+   [Tailscale Funnel](https://tailscale.com/kb/1223/funnel/), or similar,
+   then set `LAKEFS_ENDPOINT` to the tunnel URL
+3. **Override** — set `ALLOW_LOCALHOST_LAKEFS=true` if your network is configured
+   to make it work (rare; mostly useful for CI environments)
+
+---
+
+## Prerequisites
+
+| Requirement | Notes |
+|-------------|-------|
+| **E2B API key** | sign up at [e2b.dev](https://e2b.dev), key from [e2b.dev/dashboard](https://e2b.dev/dashboard) |
+| **lakeFS endpoint** | [lakeFS Cloud](https://lakefs.cloud/) or a reachable self-hosted instance |
+| **lakeFS credentials** | Access key ID + secret access key |
+| **lakeFS repository** | Create it in the UI, or set `LAKEFS_STORAGE_NAMESPACE` to auto-create |
+| **Python 3.11+** | `python --version` |
+| **uv** | `pip install uv` or see [docs.astral.sh/uv](https://docs.astral.sh/uv) |
+
+---
+
+## Setup
+
+```bash
+# 1. Clone the repo and install the uv workspace (from the repo root)
+git clone https://github.com/treeverse/lakefs-e2b-agentic-data-pr
+cd lakefs-e2b-agentic-data-pr
+uv sync
+
+# 2. Enter this use case
+cd usecases/01-sdk-orchestrator
+
+# 3. Copy and fill in the environment file
+cp .env.example .env
+# edit .env with your real values
+
+# 4. Run tests (no live credentials needed)
+uv run pytest
+```
+
+> All commands below are run from `usecases/01-sdk-orchestrator/`.
+
+---
+
+## Demo script
+
+### Step 1 — Seed demo data
+
+```bash
+uv run python -m lakefs_e2b_poc.seed
+```
+
+Uploads `raw/orders.csv` to the `main` branch and commits it.  
+The CSV has intentionally dirty rows (negative amounts, missing IDs, non-USD currencies)
+to exercise the agent's cleaning logic.
+
+**Expected output:**
+```
+Connecting to lakeFS at https://your-org.lakefscloud.io ...
+Repository 'orders-demo' is ready.
+Branch 'main' exists.
+Uploading s3://orders-demo/main/raw/orders.csv ...
+Upload complete.
+Committing 1 staged change(s) ...
+Committed: ...
+Seed complete.
+  lakeFS repo : orders-demo
+  branch      : main
+  object      : raw/orders.csv  (232 bytes, 6 data rows)
+```
+
+---
+
+### Step 2 — Pass scenario (agent succeeds → merge)
+
+```bash
+uv run python -m lakefs_e2b_poc.orchestrator --scenario pass --merge
+```
+
+Flow:
+1. Creates `agent-run-YYYYMMDD-HHMMSS-pass` from `main`
+2. Starts an E2B sandbox, uploads `agent_job.py`
+3. Agent reads `raw/orders.csv`, cleans it (2 valid rows survive), writes:
+   - `curated/orders.parquet`
+   - `reports/data_quality.json`
+   - `reports/agent_summary.md`
+4. Agent prints `{"status":"pass","rows_in":6,"rows_out":2,...}`
+5. Host commits the branch and merges it into `main`
+
+**Expected output:**
+```
+────────────────────────────────────────────────────────────
+  lakeFS: create branch
+────────────────────────────────────────────────────────────
+  Connecting to https://your-org.lakefscloud.io ...
+  Creating 'agent-run-20260515-120000-pass' from 'main' ...
+  Branch created.
+
+────────────────────────────────────────────────────────────
+  E2B: start sandbox
+────────────────────────────────────────────────────────────
+  Sandbox ID : sbx_abc123
+
+  ...
+
+────────────────────────────────────────────────────────────
+  lakeFS: merge into main
+────────────────────────────────────────────────────────────
+  Merged 'agent-run-20260515-120000-pass' → 'main'
+
+────────────────────────────────────────────────────────────
+  Done
+────────────────────────────────────────────────────────────
+  status   : pass
+  sandbox  : sbx_abc123
+  branch   : agent-run-20260515-120000-pass
+```
+
+---
+
+### Step 3 — Fail scenario (agent fails → no merge)
+
+```bash
+uv run python -m lakefs_e2b_poc.orchestrator --scenario fail
+```
+
+The agent applies an intentionally strict filter (`amount > 1000`) that produces
+0 valid rows.  It writes failure reports to the branch but the host sees
+`"status":"fail"` and refuses to merge.
+
+**Expected output:**
+```
+  ...
+────────────────────────────────────────────────────────────
+  Result: FAILED — branch NOT merged
+────────────────────────────────────────────────────────────
+  Reason  : Validation failed: expected > 0 output rows but got 0 ...
+  Branch  : agent-run-20260515-120005-fail
+  Inspect : uv run python -m lakefs_e2b_poc.inspect --ref agent-run-20260515-120005-fail
+```
+
+---
+
+### Step 4 — Inspect the result
+
+```bash
+# Inspect main (should now contain the curated data from the pass run)
+uv run python -m lakefs_e2b_poc.inspect --ref main
+
+# Inspect the failed branch
+uv run python -m lakefs_e2b_poc.inspect --ref agent-run-YYYYMMDD-HHMMSS-fail
+```
+
+**Expected output:**
+```
+Repo  : orders-demo
+Ref   : main
+Host  : https://your-org.lakefscloud.io
+
+────────────────────────────────────────────────────────────
+Objects
+────────────────────────────────────────────────────────────
+  curated/orders.parquet                               8,192 bytes
+  raw/orders.csv                                         232 bytes
+  reports/agent_summary.md                               512 bytes
+  reports/data_quality.json                              256 bytes
+
+────────────────────────────────────────────────────────────
+Recent commits
+────────────────────────────────────────────────────────────
+  a1b2c3d4e5f6  'Merge agent-run-20260515-120000-pass into main'
+  ...
+```
+
+---
+
+## What to screenshot for a blog post
+
+1. **Terminal output** — E2B sandbox ID appearing, lakeFS branch name, final status line
+2. **lakeFS branch diff** — the feature branch showing the 3 new objects vs. `main`
+3. **lakeFS commit history** — `main` with the merge commit from the pass run
+4. **Failed branch** — the `fail` branch present in the UI with its reports, clearly not merged
+
+---
+
+## API notes (verified against live docs)
+
+| Item | Behaviour observed |
+|------|--------------------|
+| `Sandbox.create(envs={})` | Env vars set at sandbox-level, available to all commands |
+| `sandbox.commands.run(cmd, timeout=N)` | Default timeout 60 s; override for long operations |
+| `sandbox.files.write(path, data)` | Accepts `str`, `bytes`, or file-like `IO` |
+| `branch.log(max_amount=N)` | Returns iterable of `Commit` objects with `.id`, `.message`, `.committer` |
+| `feature.merge_into(main)` | Merges feature branch into main; returns merge result |
+| lakeFS S3 key format | `<bucket>=<repo>`, `<key>=<branch>/<path>` |
+| `botocore.Config` checksum flags | `request_checksum_calculation="when_required"` avoids HTTP 501 errors |
+
+---
+
+## Future extensions
+
+- **LLM-generated transforms** — replace the deterministic `agent_job.py` with
+  code generated by Claude / GPT at runtime, then executed in the E2B sandbox
+- **Custom E2B template** — pre-install pandas/pyarrow/boto3 into a custom image
+  to skip the pip-install step and cut sandbox startup time
+- **lakeFS hooks** — add pre-merge hooks that run additional validation before
+  the orchestrator is allowed to merge
+- **Branch protection** — configure lakeFS branch protection rules on `main` so
+  only commits that pass quality checks can land
+- **Human approval** — add a human-in-the-loop step between "agent wrote data"
+  and "orchestrator merges"; show a diff in the terminal and ask for confirmation
+- **Credential scoping** — where lakeFS supports it, scope the agent's credentials
+  to read-only on `main` and write-only on its own branch

--- a/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/pyproject.toml
+++ b/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "lakefs-e2b-poc"
+version = "0.1.0"
+description = "Agentic Data PR: isolated compute (E2B) + isolated data branches (lakeFS)"
+requires-python = ">=3.11"
+dependencies = [
+    "e2b>=1.0.0",
+    "lakefs",
+    "boto3>=1.28.0",
+    "botocore>=1.31.0",
+    "pandas>=2.0.0",
+    "pyarrow>=12.0.0",
+    "python-dotenv>=1.0.0",
+    "rich>=13.0.0",
+    "pytest>=7.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/lakefs_e2b_poc"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+addopts = "--import-mode=importlib"

--- a/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/agent_job.py
+++ b/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/agent_job.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Agent job that runs inside an E2B sandbox.
+
+This file is uploaded to the sandbox by the orchestrator and executed there.
+It must be fully self-contained: only standard-library + pip-installed packages.
+Do NOT import anything from lakefs_e2b_poc here.
+
+Flow:
+  1. Read raw/orders.csv from lakeFS via the S3 gateway.
+  2. Clean / transform the data (pass scenario) or simulate a failure (fail scenario).
+  3. Write output objects back to the lakeFS branch via the S3 gateway.
+  4. Print a single JSON result object on the last line of stdout.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+import boto3
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+from botocore.config import Config as BotocoreConfig
+
+# ── column contract ────────────────────────────────────────────────────────────
+REQUIRED_COLUMNS = {"order_id", "customer_id", "amount", "currency", "status", "created_at"}
+REQUIRED_COLUMNS_ORDERED = ["order_id", "customer_id", "amount", "currency", "status", "created_at"]
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+def _require_env(name: str) -> str:
+    val = os.environ.get(name, "").strip()
+    if not val:
+        _die(f"Missing required environment variable: {name!r}")
+    return val
+
+
+def _log(msg: str) -> None:
+    """Progress messages go to stderr so stdout stays clean for the JSON result."""
+    print(f"[agent] {msg}", file=sys.stderr, flush=True)
+
+
+def _die(msg: str) -> None:
+    _log(f"FATAL: {msg}")
+    sys.exit(1)
+
+
+def _make_s3():
+    s3_endpoint = os.environ.get("LAKEFS_S3_ENDPOINT", "").strip() or _require_env("LAKEFS_ENDPOINT")
+    return boto3.client(
+        "s3",
+        endpoint_url=s3_endpoint,
+        aws_access_key_id=_require_env("LAKEFS_ACCESS_KEY_ID"),
+        aws_secret_access_key=_require_env("LAKEFS_SECRET_ACCESS_KEY"),
+        region_name="us-east-1",
+        config=BotocoreConfig(
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
+        ),
+    )
+
+
+def _put(s3, repo: str, key: str, body: bytes | str) -> None:
+    if isinstance(body, str):
+        body = body.encode("utf-8")
+    s3.put_object(Bucket=repo, Key=key, Body=body)
+    _log(f"wrote s3://{repo}/{key}")
+
+
+# ── data cleaning (mirrors validation.py) ─────────────────────────────────────
+
+def _clean_orders(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    available = [c for c in REQUIRED_COLUMNS_ORDERED if c in df.columns]
+    df = df[available]
+    df = df[df["order_id"].notna() & (df["order_id"].astype(str).str.strip() != "")]
+    df = df[df["customer_id"].notna() & (df["customer_id"].astype(str).str.strip() != "")]
+    df["amount"] = pd.to_numeric(df["amount"], errors="coerce")
+    df = df[df["status"] == "PAID"]
+    df = df[df["currency"] == "USD"]
+    df = df[df["amount"] > 0]
+    return df.reset_index(drop=True)
+
+
+# ── scenarios ─────────────────────────────────────────────────────────────────
+
+def _run_pass(s3, repo: str, branch: str) -> dict:
+    input_key = f"{branch}/raw/orders.csv"
+    _log(f"reading s3://{repo}/{input_key}")
+
+    obj = s3.get_object(Bucket=repo, Key=input_key)
+    raw_csv = obj["Body"].read().decode("utf-8")
+    df_in = pd.read_csv(io.StringIO(raw_csv))
+    _log(f"read {len(df_in)} rows")
+
+    missing = REQUIRED_COLUMNS - set(df_in.columns)
+    if missing:
+        _die(f"schema error — missing columns: {sorted(missing)}")
+
+    df_out = _clean_orders(df_in)
+    _log(f"after cleaning: {len(df_out)} valid rows")
+
+    # ── curated parquet ──────────────────────────────────────────────────────
+    buf = io.BytesIO()
+    pq.write_table(pa.Table.from_pandas(df_out), buf)
+    parquet_key = f"{branch}/curated/orders.parquet"
+    _put(s3, repo, parquet_key, buf.getvalue())
+
+    # ── data-quality report ──────────────────────────────────────────────────
+    ts = datetime.now(timezone.utc).isoformat()
+    quality = {
+        "status": "pass",
+        "rows_in": len(df_in),
+        "rows_out": len(df_out),
+        "rows_dropped": len(df_in) - len(df_out),
+        "filters": ["status==PAID", "currency==USD", "amount>0", "non_empty_ids"],
+        "timestamp": ts,
+    }
+    quality_key = f"{branch}/reports/data_quality.json"
+    _put(s3, repo, quality_key, json.dumps(quality, indent=2))
+
+    # ── markdown summary ─────────────────────────────────────────────────────
+    md = f"""\
+# Agent Run Summary
+
+**Scenario:** pass
+**Timestamp:** {ts}
+**Status:** PASSED ✓
+
+## Data Quality
+
+| Metric        | Value |
+|---------------|-------|
+| Rows in       | {len(df_in)} |
+| Rows out      | {len(df_out)} |
+| Rows dropped  | {len(df_in) - len(df_out)} |
+
+## Filters Applied
+
+- `status == "PAID"`
+- `currency == "USD"`
+- `amount > 0`
+- `order_id` and `customer_id` non-empty
+
+## Output Files
+
+- `curated/orders.parquet`
+- `reports/data_quality.json`
+- `reports/agent_summary.md`
+"""
+    summary_key = f"{branch}/reports/agent_summary.md"
+    _put(s3, repo, summary_key, md)
+
+    return {
+        "status": "pass",
+        "rows_in": len(df_in),
+        "rows_out": len(df_out),
+        "outputs": [parquet_key, quality_key, summary_key],
+    }
+
+
+def _run_fail(s3, repo: str, branch: str) -> dict:
+    """Reads data but applies an intentionally too-strict filter → 0 output rows → failure."""
+    input_key = f"{branch}/raw/orders.csv"
+    _log(f"reading s3://{repo}/{input_key}")
+
+    obj = s3.get_object(Bucket=repo, Key=input_key)
+    raw_csv = obj["Body"].read().decode("utf-8")
+    df_in = pd.read_csv(io.StringIO(raw_csv))
+    _log(f"read {len(df_in)} rows")
+
+    # Apply a deliberately too-strict filter so no rows survive
+    df_strict = df_in[pd.to_numeric(df_in.get("amount", pd.Series(dtype=float)), errors="coerce") > 1000]
+    _log(f"after strict filter (amount > 1000): {len(df_strict)} rows")
+
+    ts = datetime.now(timezone.utc).isoformat()
+    reason = (
+        f"Validation failed: expected > 0 output rows but got {len(df_strict)} "
+        "(applied intentional strict filter: amount > 1000)."
+    )
+    _log(reason)
+
+    quality = {
+        "status": "fail",
+        "rows_in": len(df_in),
+        "rows_out": len(df_strict),
+        "reason": reason,
+        "timestamp": ts,
+    }
+    quality_key = f"{branch}/reports/data_quality.json"
+    _put(s3, repo, quality_key, json.dumps(quality, indent=2))
+
+    md = f"""\
+# Agent Run Summary
+
+**Scenario:** fail
+**Timestamp:** {ts}
+**Status:** FAILED ✗
+
+## Reason
+
+{reason}
+
+## What happened
+
+The agent read {len(df_in)} rows from `raw/orders.csv` but applied an intentionally
+strict filter (`amount > 1000`) that produced **{len(df_strict)} valid rows**.
+
+Because the output is empty the host orchestrator will refuse to merge this branch
+into `main`, keeping the main data branch clean.
+
+## Branch available for inspection
+
+The branch remains open so you can inspect the partial outputs in the lakeFS UI.
+"""
+    summary_key = f"{branch}/reports/agent_summary.md"
+    _put(s3, repo, summary_key, md)
+
+    return {
+        "status": "fail",
+        "reason": reason,
+        "outputs": [quality_key, summary_key],
+    }
+
+
+# ── entry point ────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    repo = _require_env("LAKEFS_REPO")
+    branch = _require_env("LAKEFS_BRANCH")
+    scenario = os.environ.get("SCENARIO", "pass").strip().lower()
+
+    _log(f"starting — repo={repo}  branch={branch}  scenario={scenario}")
+
+    s3 = _make_s3()
+
+    if scenario == "pass":
+        result = _run_pass(s3, repo, branch)
+    elif scenario == "fail":
+        result = _run_fail(s3, repo, branch)
+    else:
+        result = {"status": "fail", "reason": f"unknown scenario: {scenario!r}", "outputs": []}
+
+    _log(f"done — status={result['status']}")
+
+    # The orchestrator parses the last JSON line from stdout.
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/agent_job.py
+++ b/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/agent_job.py
@@ -60,7 +60,6 @@ def _make_s3():
         config=BotocoreConfig(
             request_checksum_calculation="when_required",
             response_checksum_validation="when_required",
-            s3={"addressing_style": "path"},
         ),
     )
 

--- a/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/agent_job.py
+++ b/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/agent_job.py
@@ -60,6 +60,7 @@ def _make_s3():
         config=BotocoreConfig(
             request_checksum_calculation="when_required",
             response_checksum_validation="when_required",
+            s3={"addressing_style": "path"},
         ),
     )
 

--- a/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/config.py
+++ b/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/config.py
@@ -1,0 +1,65 @@
+"""Load and validate configuration from environment variables."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+_LOCALHOST_PATTERNS = ("localhost", "127.0.0.1", "host.docker.internal")
+
+
+@dataclass
+class Config:
+    e2b_api_key: str
+    lakefs_endpoint: str
+    lakefs_access_key_id: str
+    lakefs_secret_access_key: str
+    lakefs_repo: str
+    lakefs_main_branch: str
+    lakefs_s3_endpoint: str
+    lakefs_storage_namespace: str
+    keep_branches: bool
+    allow_localhost_lakefs: bool
+
+
+def load_config() -> Config:
+    def req(name: str) -> str:
+        val = os.environ.get(name, "").strip()
+        if not val:
+            raise SystemExit(f"ERROR: Required environment variable {name!r} is not set.")
+        return val
+
+    lakefs_endpoint = req("LAKEFS_ENDPOINT")
+    s3_endpoint = os.environ.get("LAKEFS_S3_ENDPOINT", "").strip() or lakefs_endpoint
+
+    return Config(
+        e2b_api_key=req("E2B_API_KEY"),
+        lakefs_endpoint=lakefs_endpoint,
+        lakefs_access_key_id=req("LAKEFS_ACCESS_KEY_ID"),
+        lakefs_secret_access_key=req("LAKEFS_SECRET_ACCESS_KEY"),
+        lakefs_repo=req("LAKEFS_REPO"),
+        lakefs_main_branch=os.environ.get("LAKEFS_MAIN_BRANCH", "main").strip() or "main",
+        lakefs_s3_endpoint=s3_endpoint,
+        lakefs_storage_namespace=os.environ.get("LAKEFS_STORAGE_NAMESPACE", "").strip(),
+        keep_branches=os.environ.get("KEEP_BRANCHES", "true").strip().lower() != "false",
+        allow_localhost_lakefs=os.environ.get("ALLOW_LOCALHOST_LAKEFS", "false").strip().lower() == "true",
+    )
+
+
+def check_endpoint_not_localhost(config: Config) -> None:
+    for endpoint in (config.lakefs_endpoint, config.lakefs_s3_endpoint):
+        for pattern in _LOCALHOST_PATTERNS:
+            if pattern in endpoint and not config.allow_localhost_lakefs:
+                raise SystemExit(
+                    f"ERROR: lakeFS endpoint '{endpoint}' appears to be localhost.\n\n"
+                    "E2B sandboxes run in the cloud and cannot reach your local machine.\n\n"
+                    "Options:\n"
+                    "  1. Use lakeFS Cloud (https://lakefs.io) or another publicly reachable endpoint.\n"
+                    "  2. Expose your local lakeFS via a tunnel (e.g. ngrok, Tailscale) and use "
+                    "the tunnel URL.\n"
+                    "  3. Set ALLOW_LOCALHOST_LAKEFS=true to skip this check (only useful if the "
+                    "sandbox can actually reach the endpoint)."
+                )

--- a/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/inspect.py
+++ b/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/inspect.py
@@ -51,6 +51,7 @@ def main() -> None:
         config=BotocoreConfig(
             request_checksum_calculation="when_required",
             response_checksum_validation="when_required",
+            s3={"addressing_style": "path"},
         ),
     )
 

--- a/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/inspect.py
+++ b/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/inspect.py
@@ -1,0 +1,109 @@
+"""Inspect objects and commits on a lakeFS branch.
+
+Usage:
+    uv run python -m lakefs_e2b_poc.inspect --ref main
+    uv run python -m lakefs_e2b_poc.inspect --ref agent/run-20260515-120000-pass
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+import boto3
+from botocore.config import Config as BotocoreConfig
+
+from .config import load_config
+from .lakefs_client import get_repo, make_client
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Inspect lakeFS objects and commits for a ref")
+    p.add_argument("--ref", default="main", help="Branch name or commit SHA to inspect")
+    return p.parse_args()
+
+
+def _hr() -> None:
+    print("─" * 60)
+
+
+def main() -> None:
+    args = _parse_args()
+    config = load_config()
+
+    client = make_client(
+        config.lakefs_endpoint,
+        config.lakefs_access_key_id,
+        config.lakefs_secret_access_key,
+    )
+    repo = get_repo(client, config.lakefs_repo)
+
+    print(f"\nRepo  : {config.lakefs_repo}")
+    print(f"Ref   : {args.ref}")
+    print(f"Host  : {config.lakefs_endpoint}\n")
+
+    # ── list objects via S3 gateway ─────────────────────────────────────────
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=config.lakefs_s3_endpoint,
+        aws_access_key_id=config.lakefs_access_key_id,
+        aws_secret_access_key=config.lakefs_secret_access_key,
+        region_name="us-east-1",
+        config=BotocoreConfig(
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
+        ),
+    )
+
+    _hr()
+    print("Objects")
+    _hr()
+
+    prefixes = [f"{args.ref}/raw/", f"{args.ref}/curated/", f"{args.ref}/reports/"]
+    found_any = False
+    for prefix in prefixes:
+        try:
+            response = s3.list_objects_v2(Bucket=config.lakefs_repo, Prefix=prefix)
+            for obj in response.get("Contents", []):
+                found_any = True
+                rel = obj["Key"][len(f"{args.ref}/"):]
+                size = obj["Size"]
+                print(f"  {rel:<50s}  {size:>8,} bytes")
+        except Exception as exc:
+            print(f"  ERROR listing {prefix}: {exc}", file=sys.stderr)
+
+    if not found_any:
+        print("  (no objects found under raw/, curated/, or reports/)")
+
+    # ── recent commits ───────────────────────────────────────────────────────
+    _hr()
+    print("Recent commits")
+    _hr()
+
+    try:
+        branch = repo.branch(args.ref)
+        commits = list(branch.log(max_amount=5))
+        if not commits:
+            print("  (no commits)")
+        for commit in commits:
+            short_id = str(getattr(commit, "id", "?"))[:12]
+            msg = getattr(commit, "message", "")
+            committer = getattr(commit, "committer", "")
+            meta = getattr(commit, "metadata", {}) or {}
+            print(f"  {short_id}  {msg!r}")
+            if committer:
+                print(f"            committer: {committer}")
+            if meta:
+                for k, v in meta.items():
+                    print(f"            {k}: {v}")
+    except Exception as exc:
+        err = str(exc).lower()
+        if "not found" in err or "404" in err:
+            print(f"  ERROR: ref '{args.ref}' does not exist.", file=sys.stderr)
+        else:
+            print(f"  ERROR: {exc}", file=sys.stderr)
+
+    _hr()
+
+
+if __name__ == "__main__":
+    main()

--- a/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/lakefs_client.py
+++ b/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/lakefs_client.py
@@ -1,0 +1,57 @@
+"""Thin helpers around the lakeFS high-level Python SDK."""
+from __future__ import annotations
+
+from typing import Any
+
+import lakefs
+from lakefs.client import Client
+
+
+def make_client(endpoint: str, access_key_id: str, secret_access_key: str) -> Client:
+    return Client(host=endpoint, username=access_key_id, password=secret_access_key)
+
+
+def get_repo(client: Client, repo_name: str) -> lakefs.Repository:
+    return lakefs.repository(repo_name, client=client)
+
+
+def ensure_repo_exists(client: Client, repo_name: str, storage_namespace: str = "") -> lakefs.Repository:
+    """Return the repo, creating it if it doesn't exist and storage_namespace is provided."""
+    repo = get_repo(client, repo_name)
+    try:
+        # Force an API call; raises if the repo doesn't exist
+        _ = list(repo.branches())
+        return repo
+    except Exception as exc:
+        err = str(exc).lower()
+        if "not found" in err or "404" in err or "no such repository" in err or "repository" in err:
+            if not storage_namespace:
+                raise SystemExit(
+                    f"ERROR: lakeFS repository '{repo_name}' does not exist.\n"
+                    "Either create it in the lakeFS UI or set LAKEFS_STORAGE_NAMESPACE "
+                    "to allow automatic creation.\n"
+                    "  Example: LAKEFS_STORAGE_NAMESPACE=s3://my-bucket/lakefs-data"
+                ) from exc
+            print(f"  Repository '{repo_name}' not found. Creating with namespace '{storage_namespace}'...")
+            return repo.create(storage_namespace=storage_namespace)
+        raise
+
+
+def create_branch(repo: lakefs.Repository, branch_name: str, source_ref: str) -> lakefs.Branch:
+    return repo.branch(branch_name).create(source_reference=source_ref)
+
+
+def list_uncommitted(branch: lakefs.Branch) -> list[Any]:
+    return list(branch.uncommitted())
+
+
+def commit_branch(branch: lakefs.Branch, message: str, metadata: dict[str, str]) -> Any:
+    return branch.commit(message=message, metadata=metadata)
+
+
+def merge_into_main(feature_branch: lakefs.Branch, main_branch: lakefs.Branch) -> Any:
+    return feature_branch.merge_into(main_branch)
+
+
+def delete_branch(branch: lakefs.Branch) -> None:
+    branch.delete()

--- a/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/orchestrator.py
+++ b/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/orchestrator.py
@@ -1,0 +1,214 @@
+"""Orchestrate an agentic data PR: lakeFS branch + E2B sandbox.
+
+Usage:
+    uv run python -m lakefs_e2b_poc.orchestrator --scenario pass --merge
+    uv run python -m lakefs_e2b_poc.orchestrator --scenario fail
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+from datetime import datetime, timezone
+
+from e2b import Sandbox
+
+from .config import check_endpoint_not_localhost, load_config
+from .lakefs_client import (
+    commit_branch,
+    create_branch,
+    delete_branch,
+    get_repo,
+    list_uncommitted,
+    make_client,
+    merge_into_main,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Run an agentic data PR with E2B + lakeFS")
+    p.add_argument("--scenario", choices=["pass", "fail"], default="pass", help="Which scenario to run")
+    p.add_argument("--merge", action="store_true", help="Merge into main if the scenario passes")
+    p.add_argument(
+        "--cleanup",
+        action="store_true",
+        help="Delete the feature branch after a successful merge",
+    )
+    return p.parse_args()
+
+
+def _agent_job_source() -> str:
+    return (pathlib.Path(__file__).parent / "agent_job.py").read_text()
+
+
+def _parse_result(stdout: str) -> dict:
+    """Find the last JSON object in stdout."""
+    for line in reversed(stdout.strip().splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                return json.loads(line)
+            except json.JSONDecodeError:
+                continue
+    return {"status": "fail", "reason": "Agent produced no parseable JSON output", "outputs": []}
+
+
+def _section(title: str) -> None:
+    print(f"\n{'─'*60}")
+    print(f"  {title}")
+    print(f"{'─'*60}")
+
+
+def main() -> None:
+    args = _parse_args()
+    config = load_config()
+    check_endpoint_not_localhost(config)
+
+    # ── 1. Create branch name ──────────────────────────────────────────────────
+    now = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    branch_name = f"agent-run-{now}-{args.scenario}"
+
+    _section("lakeFS: create branch")
+    print(f"  Connecting to {config.lakefs_endpoint} ...")
+    client = make_client(
+        config.lakefs_endpoint,
+        config.lakefs_access_key_id,
+        config.lakefs_secret_access_key,
+    )
+    repo = get_repo(client, config.lakefs_repo)
+
+    print(f"  Creating '{branch_name}' from '{config.lakefs_main_branch}' ...")
+    branch = create_branch(repo, branch_name, config.lakefs_main_branch)
+    print(f"  Branch created.")
+
+    # ── 2. E2B sandbox ────────────────────────────────────────────────────────
+    _section("E2B: start sandbox")
+    sandbox = None
+    result: dict = {"status": "fail", "reason": "Sandbox did not complete", "outputs": []}
+    sandbox_id: str | None = None
+
+    try:
+        sandbox = Sandbox.create(
+            envs={
+                "LAKEFS_ENDPOINT": config.lakefs_endpoint,
+                "LAKEFS_S3_ENDPOINT": config.lakefs_s3_endpoint,
+                "LAKEFS_ACCESS_KEY_ID": config.lakefs_access_key_id,
+                "LAKEFS_SECRET_ACCESS_KEY": config.lakefs_secret_access_key,
+                "LAKEFS_REPO": config.lakefs_repo,
+                "LAKEFS_BRANCH": branch_name,
+                "SCENARIO": args.scenario,
+            }
+        )
+        sandbox_id = getattr(sandbox, "sandbox_id", None) or getattr(sandbox, "id", None)
+        print(f"  Sandbox ID : {sandbox_id}")
+
+        # ── 3. Upload agent_job.py ─────────────────────────────────────────────
+        _section("E2B: upload agent_job.py")
+        sandbox.files.write("/home/user/agent_job.py", _agent_job_source())
+        print("  agent_job.py uploaded.")
+
+        # ── 4. Install runtime deps ────────────────────────────────────────────
+        _section("E2B: install dependencies")
+        install = sandbox.commands.run(
+            "python -m pip install -q pandas pyarrow boto3 botocore",
+            timeout=180,
+        )
+        if install.exit_code != 0:
+            print(f"  WARNING: pip install exited {install.exit_code}")
+            if install.stderr:
+                print(install.stderr)
+        else:
+            print("  Dependencies installed.")
+
+        # ── 5. Run agent ───────────────────────────────────────────────────────
+        _section(f"E2B: run agent (scenario={args.scenario})")
+        run = sandbox.commands.run(
+            "python /home/user/agent_job.py",
+            timeout=300,
+        )
+
+        if run.stderr:
+            print("  [stderr]")
+            for line in run.stderr.strip().splitlines():
+                print(f"    {line}")
+
+        print(f"\n  [stdout]\n    {run.stdout.strip() if run.stdout else '(empty)'}")
+        print(f"\n  Exit code: {run.exit_code}")
+
+        result = _parse_result(run.stdout or "")
+
+    except Exception as exc:
+        print(f"\n  ERROR: {exc}", file=sys.stderr)
+        result = {"status": "fail", "reason": str(exc), "outputs": []}
+
+    finally:
+        if sandbox is not None:
+            try:
+                sandbox.kill()
+            except Exception:
+                pass
+
+    # ── 6. Commit lakeFS branch ────────────────────────────────────────────────
+    _section("lakeFS: uncommitted changes")
+    changes = list_uncommitted(branch)
+    if changes:
+        for c in changes:
+            print(f"  {c.type:10s}  {c.path}")
+    else:
+        print("  (none)")
+
+    _section("lakeFS: commit branch")
+    metadata: dict[str, str] = {
+        "scenario": args.scenario,
+        "validation_status": result.get("status", "unknown"),
+    }
+    if sandbox_id:
+        metadata["e2b_sandbox_id"] = sandbox_id
+    if "rows_in" in result:
+        metadata["rows_in"] = str(result["rows_in"])
+    if "rows_out" in result:
+        metadata["rows_out"] = str(result["rows_out"])
+
+    commit_ref = commit_branch(
+        branch,
+        f"Agent run {args.scenario} from E2B sandbox",
+        metadata,
+    )
+    print(f"  Committed: {commit_ref}")
+
+    # ── 7. Merge or report failure ────────────────────────────────────────────
+    if result.get("status") == "pass" and args.merge:
+        _section("lakeFS: merge into main")
+        main_branch = repo.branch(config.lakefs_main_branch)
+        merge_result = merge_into_main(branch, main_branch)
+        print(f"  Merged '{branch_name}' → '{config.lakefs_main_branch}'")
+        print(f"  Merge result: {merge_result}")
+
+        if args.cleanup:
+            print(f"  Deleting branch '{branch_name}' (--cleanup) ...")
+            delete_branch(branch)
+            print("  Branch deleted.")
+        else:
+            print(f"\n  Branch '{branch_name}' kept for inspection (pass --cleanup to delete).")
+
+    elif result.get("status") == "fail":
+        _section("Result: FAILED — branch NOT merged")
+        print(f"  Reason  : {result.get('reason', 'unknown')}")
+        print(f"  Branch  : {branch_name}")
+        print(f"  Inspect : uv run python -m lakefs_e2b_poc.inspect --ref {branch_name!r}")
+
+    else:
+        _section("Result: PASSED — no merge requested")
+        print(f"  Branch  : {branch_name}")
+        print("  (Re-run with --merge to merge into main.)")
+
+    _section("Done")
+    print(f"  status   : {result.get('status')}")
+    if sandbox_id:
+        print(f"  sandbox  : {sandbox_id}")
+    print(f"  branch   : {branch_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/seed.py
+++ b/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/seed.py
@@ -1,0 +1,87 @@
+"""Seed demo data into the lakeFS repository.
+
+Usage:
+    uv run python -m lakefs_e2b_poc.seed
+"""
+from __future__ import annotations
+
+import sys
+
+import boto3
+from botocore.config import Config as BotocoreConfig
+
+from .config import load_config
+from .lakefs_client import commit_branch, ensure_repo_exists, list_uncommitted, make_client
+
+SEED_CSV = """\
+order_id,customer_id,amount,currency,status,created_at
+1001,c001,120.50,USD,PAID,2026-05-01
+1002,c002,-7.00,USD,PAID,2026-05-01
+1003,c003,50.00,EUR,PAID,2026-05-02
+1004,c004,,USD,CANCELLED,2026-05-03
+1005,c005,200.00,USD,PAID,2026-05-04
+1006,,15.00,USD,PAID,2026-05-04
+"""
+
+
+def main() -> None:
+    config = load_config()
+
+    print(f"Connecting to lakeFS at {config.lakefs_endpoint} ...")
+    client = make_client(
+        config.lakefs_endpoint,
+        config.lakefs_access_key_id,
+        config.lakefs_secret_access_key,
+    )
+
+    repo = ensure_repo_exists(client, config.lakefs_repo, config.lakefs_storage_namespace)
+    print(f"Repository '{config.lakefs_repo}' is ready.")
+
+    # Verify the main branch exists
+    branch = repo.branch(config.lakefs_main_branch)
+    try:
+        branch.get_commit()
+        print(f"Branch '{config.lakefs_main_branch}' exists.")
+    except Exception as exc:
+        print(f"ERROR: Cannot access branch '{config.lakefs_main_branch}': {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    # Upload seed CSV via the S3 gateway (writes to the branch's staging area)
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=config.lakefs_s3_endpoint,
+        aws_access_key_id=config.lakefs_access_key_id,
+        aws_secret_access_key=config.lakefs_secret_access_key,
+        region_name="us-east-1",
+        config=BotocoreConfig(
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
+        ),
+    )
+
+    key = f"{config.lakefs_main_branch}/raw/orders.csv"
+    print(f"Uploading s3://{config.lakefs_repo}/{key} ...")
+    s3.put_object(Bucket=config.lakefs_repo, Key=key, Body=SEED_CSV.encode("utf-8"))
+    print("Upload complete.")
+
+    # Only commit if there are staged changes (idempotency)
+    changes = list_uncommitted(branch)
+    if not changes:
+        print("No uncommitted changes — seed already applied, nothing to commit.")
+        return
+
+    print(f"Committing {len(changes)} staged change(s) ...")
+    ref = commit_branch(
+        branch,
+        "Seed demo orders data for E2B/lakeFS POC",
+        {"source": "seed"},
+    )
+    print(f"Committed: {ref}")
+    print("\nSeed complete.")
+    print(f"  lakeFS repo : {config.lakefs_repo}")
+    print(f"  branch      : {config.lakefs_main_branch}")
+    print(f"  object      : raw/orders.csv  ({len(SEED_CSV)} bytes, {len(SEED_CSV.splitlines())-1} data rows)")
+
+
+if __name__ == "__main__":
+    main()

--- a/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/seed.py
+++ b/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/seed.py
@@ -56,6 +56,7 @@ def main() -> None:
         config=BotocoreConfig(
             request_checksum_calculation="when_required",
             response_checksum_validation="when_required",
+            s3={"addressing_style": "path"},
         ),
     )
 

--- a/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/validation.py
+++ b/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/src/lakefs_e2b_poc/validation.py
@@ -1,0 +1,52 @@
+"""Pure-Python validation and cleaning logic — no lakeFS or E2B dependencies.
+
+These functions are used by both agent_job.py (inside the E2B sandbox) and
+the test suite.  agent_job.py duplicates this logic so it can run as a
+standalone script without the lakefs_e2b_poc package installed.
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+REQUIRED_COLUMNS = {"order_id", "customer_id", "amount", "currency", "status", "created_at"}
+REQUIRED_COLUMNS_ORDERED = ["order_id", "customer_id", "amount", "currency", "status", "created_at"]
+
+
+def validate_schema(df: pd.DataFrame) -> tuple[bool, str]:
+    """Return (True, '') if df has all required columns, else (False, error_message)."""
+    missing = REQUIRED_COLUMNS - set(df.columns)
+    if missing:
+        return False, f"Missing required columns: {sorted(missing)}"
+    return True, ""
+
+
+def clean_orders(df: pd.DataFrame) -> pd.DataFrame:
+    """Return only valid PAID/USD/positive-amount rows with non-empty IDs."""
+    df = df.copy()
+
+    # Keep only the required columns (preserves order)
+    available = [c for c in REQUIRED_COLUMNS_ORDERED if c in df.columns]
+    df = df[available]
+
+    # Drop rows with empty or null order_id / customer_id
+    df = df[df["order_id"].notna() & (df["order_id"].astype(str).str.strip() != "")]
+    df = df[df["customer_id"].notna() & (df["customer_id"].astype(str).str.strip() != "")]
+
+    # Coerce amount to numeric (invalid → NaN, which will be filtered out below)
+    df["amount"] = pd.to_numeric(df["amount"], errors="coerce")
+
+    # Apply business filters
+    df = df[df["status"] == "PAID"]
+    df = df[df["currency"] == "USD"]
+    df = df[df["amount"] > 0]
+
+    return df.reset_index(drop=True)
+
+
+def build_quality_report(df_in: pd.DataFrame, df_out: pd.DataFrame) -> dict:
+    return {
+        "rows_in": len(df_in),
+        "rows_out": len(df_out),
+        "rows_dropped": len(df_in) - len(df_out),
+        "filters_applied": ["status==PAID", "currency==USD", "amount>0", "non_empty_ids"],
+    }

--- a/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/tests/test_validation.py
+++ b/01_standalone_examples/e2b/usecases/01-sdk-orchestrator/tests/test_validation.py
@@ -1,0 +1,160 @@
+"""Unit tests for validation logic.
+
+These tests do not call E2B or lakeFS — they work entirely on in-memory DataFrames.
+"""
+from __future__ import annotations
+
+import io
+
+import pandas as pd
+import pytest
+
+from lakefs_e2b_poc.validation import (
+    REQUIRED_COLUMNS,
+    build_quality_report,
+    clean_orders,
+    validate_schema,
+)
+
+# The same seed CSV the seed module uploads to lakeFS
+SEED_CSV = """\
+order_id,customer_id,amount,currency,status,created_at
+1001,c001,120.50,USD,PAID,2026-05-01
+1002,c002,-7.00,USD,PAID,2026-05-01
+1003,c003,50.00,EUR,PAID,2026-05-02
+1004,c004,,USD,CANCELLED,2026-05-03
+1005,c005,200.00,USD,PAID,2026-05-04
+1006,,15.00,USD,PAID,2026-05-04
+"""
+
+
+def _df(csv: str) -> pd.DataFrame:
+    return pd.read_csv(io.StringIO(csv))
+
+
+# ── pass scenario ──────────────────────────────────────────────────────────────
+
+class TestCleanOrders:
+    def test_keeps_only_valid_rows(self):
+        """Rows 1001 and 1005 are the only fully valid PAID/USD/positive/non-empty rows."""
+        df = _df(SEED_CSV)
+        clean = clean_orders(df)
+        assert len(clean) == 2
+        assert sorted(clean["order_id"].tolist()) == [1001, 1005]
+
+    def test_all_remaining_paid(self):
+        clean = clean_orders(_df(SEED_CSV))
+        assert (clean["status"] == "PAID").all()
+
+    def test_all_remaining_usd(self):
+        clean = clean_orders(_df(SEED_CSV))
+        assert (clean["currency"] == "USD").all()
+
+    def test_all_remaining_positive_amount(self):
+        clean = clean_orders(_df(SEED_CSV))
+        assert (clean["amount"] > 0).all()
+
+    def test_no_empty_order_id(self):
+        clean = clean_orders(_df(SEED_CSV))
+        assert clean["order_id"].notna().all()
+
+    def test_no_empty_customer_id(self):
+        clean = clean_orders(_df(SEED_CSV))
+        assert clean["customer_id"].notna().all()
+
+    def test_drops_negative_amount(self):
+        """Row 1002 has amount=-7.00 and must be dropped."""
+        df = _df(SEED_CSV)
+        clean = clean_orders(df)
+        assert 1002 not in clean["order_id"].tolist()
+
+    def test_drops_non_usd(self):
+        """Row 1003 is EUR and must be dropped."""
+        df = _df(SEED_CSV)
+        clean = clean_orders(df)
+        assert 1003 not in clean["order_id"].tolist()
+
+    def test_drops_cancelled(self):
+        """Row 1004 is CANCELLED and must be dropped."""
+        df = _df(SEED_CSV)
+        clean = clean_orders(df)
+        assert 1004 not in clean["order_id"].tolist()
+
+    def test_drops_empty_customer_id(self):
+        """Row 1006 has empty customer_id and must be dropped."""
+        df = _df(SEED_CSV)
+        clean = clean_orders(df)
+        assert 1006 not in clean["order_id"].tolist()
+
+    def test_idempotent(self):
+        """Cleaning already-clean data should be a no-op."""
+        df = _df(SEED_CSV)
+        once = clean_orders(df)
+        twice = clean_orders(once)
+        assert len(once) == len(twice)
+
+
+# ── fail scenario ──────────────────────────────────────────────────────────────
+
+class TestFailScenario:
+    def test_strict_filter_produces_zero_rows(self):
+        """The fail scenario uses amount > 1000; none of the seed rows satisfy that."""
+        df = _df(SEED_CSV)
+        df["amount"] = pd.to_numeric(df["amount"], errors="coerce")
+        strict = df[df["amount"] > 1000]
+        assert len(strict) == 0
+
+    def test_zero_rows_maps_to_fail_status(self):
+        """If the agent outputs 0 rows it should report status='fail'."""
+        df_out = pd.DataFrame(columns=list(REQUIRED_COLUMNS))
+        status = "fail" if len(df_out) == 0 else "pass"
+        assert status == "fail"
+
+
+# ── schema validation ──────────────────────────────────────────────────────────
+
+class TestValidateSchema:
+    def test_accepts_all_required_columns(self):
+        df = _df(SEED_CSV)
+        ok, msg = validate_schema(df)
+        assert ok is True
+        assert msg == ""
+
+    def test_rejects_missing_single_column(self):
+        df = _df(SEED_CSV).drop(columns=["amount"])
+        ok, msg = validate_schema(df)
+        assert ok is False
+        assert "amount" in msg
+
+    def test_rejects_multiple_missing_columns(self):
+        df = pd.DataFrame({"order_id": [1], "amount": [10.0]})
+        ok, msg = validate_schema(df)
+        assert ok is False
+        assert "Missing required columns" in msg
+        # customer_id, currency, status, created_at are all missing
+        assert len(REQUIRED_COLUMNS - set(df.columns)) >= 4
+
+    def test_accepts_extra_columns(self):
+        df = _df(SEED_CSV)
+        df["extra_col"] = "whatever"
+        ok, msg = validate_schema(df)
+        assert ok is True
+
+
+# ── quality report ─────────────────────────────────────────────────────────────
+
+class TestBuildQualityReport:
+    def test_counts_are_correct(self):
+        df_in = _df(SEED_CSV)
+        df_out = clean_orders(df_in)
+        report = build_quality_report(df_in, df_out)
+        assert report["rows_in"] == len(df_in)
+        assert report["rows_out"] == len(df_out)
+        assert report["rows_dropped"] == len(df_in) - len(df_out)
+
+    def test_contains_filter_list(self):
+        df_in = _df(SEED_CSV)
+        df_out = clean_orders(df_in)
+        report = build_quality_report(df_in, df_out)
+        assert "filters_applied" in report
+        assert len(report["filters_applied"]) > 0

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/.env.example
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/.env.example
@@ -1,0 +1,14 @@
+# Required
+OPENAI_API_KEY=sk-...
+E2B_API_KEY=e2b_...
+E2B_TEAM=your-e2b-team-slug   # optional — adds a sandbox link button in lakeFS commit metadata
+LAKEFS_ENDPOINT=https://your-org.lakefscloud.io
+LAKEFS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+LAKEFS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+LAKEFS_REPOSITORY=data-agent-demo
+
+# Optional
+LAKEFS_STORAGE_NAMESPACE=s3://your-bucket/data-agent-demo/
+LAKEFS_BRANCH=main
+OPENAI_MODEL=gpt-4o-mini
+MAX_ATTEMPTS=5

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/README.md
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/README.md
@@ -201,9 +201,9 @@ After all three phases pass, 4 valid rows remain.
 ## Quickstart
 
 ```bash
-# 1. Clone the repo and install the uv workspace (from the repo root)
-git clone https://github.com/treeverse/lakefs-e2b-agentic-data-pr
-cd lakefs-e2b-agentic-data-pr
+# 1. Clone lakeFS-samples and install the uv workspace (from this example's root)
+git clone https://github.com/treeverse/lakeFS-samples
+cd lakeFS-samples/01_standalone_examples/e2b
 uv sync
 
 # 2. Enter this use case (all commands below run from here)

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/README.md
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/README.md
@@ -1,0 +1,356 @@
+# Use Case 2 — AI Data Agent: E2B + lakeFS + OpenAI
+
+> Part of [**Agentic Data Patterns: E2B + lakeFS**](../../README.md). See the repo root for the full set of use cases.
+
+> An AI agent repairs a broken dataset — iteratively, in isolation, with a full audit trail — and only promotes clean data to production.
+
+---
+
+## The problem this solves
+
+When an AI agent writes data, three things can go wrong:
+
+- **The generated code crashes** — and you have no record of what it tried.
+- **The output passes local checks but fails downstream business rules** — and the bad data lands in production.
+- **You can't reproduce or audit what the agent did** — so debugging or rolling back is manual.
+
+This demo shows one way to solve all three using **E2B** for isolated execution and **lakeFS** as the control plane for AI-ready data.
+
+---
+
+## Demo story
+
+A dirty e-commerce orders CSV is uploaded to a lakeFS repository. An AI agent — powered by OpenAI — is asked to repair it.
+
+The agent works iteratively through **three progressive validation phases**:
+
+| Phase | What is checked | Example failures in the sample data |
+|-------|----------------|--------------------------------------|
+| **1 — Structural Integrity** | Required fields present, no duplicate IDs, amount parseable | Missing `customer_id`, duplicate `ORD-001` |
+| **2 — Format & Value Conformance** | Date format valid, amount > 0, currency = USD, enums lowercase | `SHIPPED` instead of `shipped`, date `01/17/2024`, amount `0.00`, currency `EUR` |
+| **3 — Business Rules** | Order year ≥ 2023, amount ≤ $350 | `ORD-012` dated 2022, amount $420 |
+
+On each attempt the agent:
+1. Reads the current data from an isolated lakeFS branch
+2. Is told **only the rules for the current failing phase** (it doesn't see Phase 2 or 3 rules until it earns them)
+3. Asks OpenAI to generate Python repair code
+4. Runs that code inside a disposable E2B sandbox
+5. Validates the output and **commits the result to lakeFS** — pass or fail
+6. Moves to the next phase once the current one passes
+
+Only when all three phases pass does the branch merge into `main`, enforced by a **lakeFS pre-merge Action** that physically blocks any other promotion path.
+
+The result is a lakeFS branch with 3–5 commits showing exactly how the agent progressed from broken to clean — each commit labelled with its phase and outcome.
+
+---
+
+## What you'll see
+
+```
+  Creating branch 'agent-run-20260529-201520' from 'main'...
+  Branch created.
+────────────────────────────────────────────────────────────
+  Attempt 1/5
+────────────────────────────────────────────────────────────
+  Phase 1 (Structural Integrity): 2 failure(s)
+    • order_id_unique: rows [6]
+    • customer_id_required: rows [2]
+  Generating repair code via OpenAI (gpt-4o-mini)...
+  Running repair in E2B sandbox...
+  Sandbox: i3n6e5kv3k3mkngkaxwox
+  Result: phase 2 still failing — 10 rows, phase 2 (Format & Value Conformance) failed
+  Committed: 2c90082ec01d
+────────────────────────────────────────────────────────────
+  Attempt 2/5
+────────────────────────────────────────────────────────────
+  Phase 2 (Format & Value Conformance): 5 failure(s)
+    • order_date_format: rows [2, 5]
+    • amount_positive: rows [2, 4]
+    • currency_usd: rows [6]
+    • status_valid: rows [3, 7]
+    • product_category_valid: rows [4, 8]
+  ...
+  Committed: 4e33f0978fcc
+────────────────────────────────────────────────────────────
+  Attempt 4/5
+────────────────────────────────────────────────────────────
+  Phase 2 (Format & Value Conformance): 5 failure(s)
+  ...
+  Result: phase 3 still failing — 5 rows, phase 3 (Business Rules) failed
+  Committed: d688bcfff4a1
+────────────────────────────────────────────────────────────
+  Attempt 5/5
+────────────────────────────────────────────────────────────
+  Phase 3 (Business Rules): 2 failure(s)
+    • date_recency: rows [5]
+    • amount_ceiling: rows [5]
+  ...
+  Result: PASSED — 4 rows, all phases passed
+  Committed: 1cb832d99dc1
+
+────────────────────────────────────────────────────────────
+  Final Report
+────────────────────────────────────────────────────────────
+  Branch      : agent-run-20260529-201520
+  Total attempts: 5
+  Outcome     : PASSED
+
+  Attempt 1: [FAIL]  commit=2c90082ec01d  phase 1 → phase 2 exposed
+  Attempt 2: [FAIL]  commit=4e33f0978fcc  execution error
+  Attempt 3: [FAIL]  commit=cb63e57263a6  execution error
+  Attempt 4: [FAIL]  commit=d688bcfff4a1  phase 2 → phase 3 exposed
+  Attempt 5: [PASS]  commit=1cb832d99dc1  4 rows, all phases passed
+
+  Merging 'agent-run-20260529-201520' into 'main'...
+  Merged successfully.
+```
+
+Every commit — including failed attempts and execution errors — is permanently recorded in lakeFS.
+
+---
+
+## Architecture
+
+```
+                        ┌─────────────────────┐
+                        │   OpenAI API        │
+                        │   code generation   │
+                        └─────────┬───────────┘
+                                  │ Python repair code (per phase)
+                                  ▼
+┌────────────────────────────────────────────────────────────┐
+│                  Agent Loop (orchestrator)                  │
+│                                                             │
+│  validate → (phase 1?) → generate → E2B → validate         │
+│                ↓ pass                                       │
+│  validate → (phase 2?) → generate → E2B → validate         │
+│                ↓ pass                                       │
+│  validate → (phase 3?) → generate → E2B → validate         │
+│                ↓ pass → commit → merge                      │
+│                                                             │
+│  Every attempt committed to lakeFS (pass or fail)          │
+└────────┬──────────────────────────────┬────────────────────┘
+         │                              │
+         ▼                              ▼
+┌─────────────────┐            ┌──────────────────────┐
+│    lakeFS       │            │   E2B Cloud Sandbox  │
+│                 │◄──────────►│                      │
+│ • feature branch│  read CSV  │  /tmp/input.csv      │
+│ • raw/          │  write CSV │  /tmp/repair_code.py │
+│ • curated/      │            │  /tmp/output.csv     │
+│ • validation/   │            │                      │
+│ • code/         │            │  No access to your   │
+│ • pre-merge gate│            │  network or infra    │
+└────────┬────────┘            └──────────────────────┘
+         │ merge only on phase 3 pass
+         ▼
+      main branch
+```
+
+---
+
+## Why E2B and lakeFS together
+
+| | E2B | lakeFS |
+|---|---|---|
+| **Isolation** | Each repair attempt runs in a fresh cloud VM — generated code cannot reach your network, credentials, or internal APIs | Each agent run gets its own data branch — intermediate and failed states never touch `main` |
+| **Safety** | Sandbox is killed after every attempt, leaving no persistent state | Pre-merge Action physically blocks promotion unless the latest validation result is `"passed"` |
+| **Auditability** | Stdout, stderr, exit code, and the generated code itself are captured per attempt | Every attempt — including failures and crashes — is a permanent, immutable lakeFS commit |
+| **Reproducibility** | The exact repair code that produced the passing output is stored on the lakeFS branch | Any commit can be checked out and re-run against its exact input data |
+
+---
+
+## Sample dataset
+
+`data/sample_bad_data.csv` contains 12 rows of intentionally broken e-commerce orders. The violations are spread across all three validation phases:
+
+**Phase 1 — Structural** (obvious, agent sees these first):
+- `ORD-002`: missing `customer_id`
+- `ORD-001` appears twice (duplicate order ID)
+
+**Phase 2 — Format & Values** (only visible after Phase 1 is clean):
+- `ORD-003`: date in `MM/DD/YYYY` format, negative amount
+- `ORD-004`: status `SHIPPED` (wrong case)
+- `ORD-005`: amount `0.00`, category `Electronics` (wrong case)
+- `ORD-007`: impossible date — month 13
+- `ORD-008`: currency `EUR`
+- `ORD-009`: status `unknown_status`
+- `ORD-010`: category `CLOTHING` (wrong case)
+
+**Phase 3 — Business Rules** (only visible after Phase 2 is clean):
+- `ORD-012`: order dated 2022 (stale — year < 2023) and amount $420 (exceeds $350 threshold)
+
+After all three phases pass, 4 valid rows remain.
+
+---
+
+## Prerequisites
+
+| Requirement | Notes |
+|-------------|-------|
+| **OpenAI API key** | [platform.openai.com](https://platform.openai.com) |
+| **E2B API key** | sign up at [e2b.dev](https://e2b.dev), key from [e2b.dev/dashboard](https://e2b.dev/dashboard) |
+| **lakeFS endpoint** | [lakeFS Cloud](https://lakefs.cloud/) or a self-hosted instance reachable from the internet |
+| **lakeFS credentials** | Access key ID + secret access key |
+| **lakeFS repository** | Create in the UI, or set `LAKEFS_STORAGE_NAMESPACE` to auto-create |
+| **Python 3.11+** | `python --version` |
+| **uv** | `pip install uv` or [docs.astral.sh/uv](https://docs.astral.sh/uv) |
+
+---
+
+## Quickstart
+
+```bash
+# 1. Clone the repo and install the uv workspace (from the repo root)
+git clone https://github.com/treeverse/lakefs-e2b-agentic-data-pr
+cd lakefs-e2b-agentic-data-pr
+uv sync
+
+# 2. Enter this use case (all commands below run from here)
+cd usecases/02-three-phase-repair
+
+# 3. Configure
+cp .env.example .env
+# Fill in OPENAI_API_KEY, E2B_API_KEY, LAKEFS_* in .env
+
+# 4. Create the lakeFS repo and install the pre-merge gate
+uv run python scripts/setup_lakefs_repo.py
+
+# 5. Upload the sample broken dataset
+uv run python scripts/upload_sample_data.py
+
+# 6. Run the agent
+uv run python -m agent_demo.main
+```
+
+Or run steps 4–6 in one command:
+```bash
+uv run python scripts/run_demo.py
+```
+
+---
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `OPENAI_API_KEY` | Yes | — | OpenAI API key |
+| `E2B_API_KEY` | Yes | — | E2B API key |
+| `LAKEFS_ENDPOINT` | Yes | — | lakeFS server URL |
+| `LAKEFS_ACCESS_KEY_ID` | Yes | — | lakeFS access key ID |
+| `LAKEFS_SECRET_ACCESS_KEY` | Yes | — | lakeFS secret access key |
+| `LAKEFS_REPOSITORY` | Yes | — | lakeFS repository name |
+| `LAKEFS_STORAGE_NAMESPACE` | No | — | Storage path for auto-creating the repo (e.g. `s3://bucket/path/`) |
+| `LAKEFS_BRANCH` | No | `main` | Source branch to read data from |
+| `OPENAI_MODEL` | No | `gpt-4o-mini` | OpenAI model for code generation |
+| `MAX_ATTEMPTS` | No | `5` | Maximum repair attempts |
+
+---
+
+## Inspecting results
+
+**Objects written per agent run:**
+```
+raw/orders.csv                     source data (read-only, from main)
+curated/repaired_orders.csv        latest repaired output
+validation/latest_result.json      final validation state (read by pre-merge gate)
+validation/attempt_N_result.json   per-attempt validation history
+code/repair_attempt_N.py           the exact code OpenAI generated for each attempt
+```
+
+**In the lakeFS UI:** open the feature branch (`agent-run-YYYYMMDD-HHMMSS`) and browse the commit log. Each commit message names the phase and outcome: `Attempt 3 — phase 2 (Format & Value Conformance): failed`.
+
+**Via lakectl:**
+```bash
+# Commit history for a run
+lakectl log lakefs://data-agent-e2b-demo/agent-run-20260529-201520
+
+# See exactly what changed vs main
+lakectl diff lakefs://data-agent-e2b-demo/main lakefs://data-agent-e2b-demo/agent-run-20260529-201520
+
+# Read the validation result
+lakectl fs cat lakefs://data-agent-e2b-demo/agent-run-20260529-201520/validation/latest_result.json
+
+# Read the repair code from attempt 3
+lakectl fs cat lakefs://data-agent-e2b-demo/agent-run-20260529-201520/code/repair_attempt_3.py
+```
+
+**Test the pre-merge gate on a failed branch:**
+```bash
+# This will be blocked by the lakeFS Action
+lakectl merge lakefs://data-agent-e2b-demo/agent-run-20260529-195356 lakefs://data-agent-e2b-demo/main
+# Error: Pre-merge gate FAILED: latest validation did not pass.
+```
+
+---
+
+## How the pre-merge gate works — and why it matters
+
+`lakefs_actions/validate_data.yaml` defines a lakeFS Action that runs on every merge attempt into `main`. It is a Lua script that:
+
+1. Reads `validation/latest_result.json` from the source branch
+2. Checks whether `status == "passed"`
+3. Blocks the merge with a descriptive error if not
+
+The setup script uploads this file to `_lakefs_actions/validate_data.yaml` on the `main` branch, where lakeFS picks it up automatically.
+
+**Isn't this redundant with the Python check?**
+
+In this demo, the orchestrator already checks `if result.passed` before calling merge, so on the happy path the hook and the application code enforce the same thing. That's intentional — and worth explaining honestly.
+
+The hook's value is not about this demo's code path. It's about every *other* merge path that the orchestrator doesn't control:
+
+- `lakectl merge` run directly from a terminal
+- A merge triggered from the lakeFS UI
+- Another service or CI job calling the lakeFS API
+- A modified version of this script that removes the check
+
+In all of those cases, the Python-side check does nothing. The hook is the only thing that enforces the gate. It runs server-side, before the merge is applied, regardless of what client triggered it.
+
+This distinction matters in real enterprise deployments where multiple teams, services, and tools have write access to the same repository. "The application checked before merging" is not sufficient for compliance or auditability — "the storage system enforced it at the infrastructure layer" is.
+
+To see the hook block a real merge attempt, run:
+
+```bash
+# The first failed run left its branch un-merged — try to force-merge it
+lakectl merge lakefs://data-agent-e2b-demo/agent-run-20260529-195356 lakefs://data-agent-e2b-demo/main
+# Error: Pre-merge gate FAILED: latest validation did not pass.
+```
+
+---
+
+## Mapping to real enterprise AI infrastructure
+
+This pattern addresses a genuine problem in production AI platforms: **agents that write to data need the same guardrails as humans that write to data — isolation, validation, and controlled promotion.**
+
+The same architecture applies to:
+- **LLM fine-tuning pipelines** — agent-generated training data goes through quality gates before joining the training set
+- **Feature engineering** — agent-computed features are validated against schema and distribution checks before landing in the feature store
+- **Model evaluation datasets** — curated test sets are versioned and gated so evaluation results are reproducible
+
+In each case: E2B provides compute isolation (the agent's code can't reach production systems), lakeFS provides data isolation (the agent's output can't reach production data until it passes), and the pre-merge gate provides the enforcement point.
+
+---
+
+## Related: lakeFS Mount (FUSE)
+
+This demo passes data through the lakeFS Python SDK. **Use case 3 — [`../03-mount-receipts`](../03-mount-receipts)** shows the lakeFS **Mount** approach instead: the branch is exposed as a mounted filesystem inside the E2B sandbox, so the agent reads and writes with ordinary file I/O (`/mnt/repo/...`) — no SDK calls, no S3 knowledge — and versions each pass with `everest commit`. The isolation and pre-merge gate remain identical. E2B's full kernel access (including FUSE) makes this possible.
+
+---
+
+## Troubleshooting
+
+**`ERROR: Required environment variable 'X' is not set`**
+Your `.env` file is missing or incomplete. Run `cp .env.example .env` and fill in all required values.
+
+**`ERROR: lakeFS repository '...' does not exist`**
+Create the repository in the lakeFS UI, or set `LAKEFS_STORAGE_NAMESPACE` to a valid storage path to allow auto-creation.
+
+**All attempts fail with `execution_error`**
+The generated code crashed inside E2B. The stderr from the sandbox is included in `validation/attempt_N_result.json` on the branch, and is also fed back to the LLM on the next attempt. Switching to `OPENAI_MODEL=gpt-4o` improves code quality significantly.
+
+**Stuck on the same phase after multiple attempts**
+Inspect the generated code at `code/repair_attempt_N.py` on the feature branch. Common causes: the LLM doesn't know about a data edge case, or the validation rule description isn't specific enough. The validation failure description is the primary signal the LLM acts on.
+
+**Pre-merge gate blocks a merge you want to force**
+Edit or delete `_lakefs_actions/validate_data.yaml` on `main`. This is intentional — the gate is a guardrail, not a suggestion.

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/data/sample_bad_data.csv
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/data/sample_bad_data.csv
@@ -1,0 +1,13 @@
+order_id,customer_id,order_date,amount,currency,status,product_category
+ORD-001,CUST-101,2024-01-15,150.50,USD,completed,electronics
+ORD-002,,2024-01-16,200.00,USD,completed,clothing
+ORD-003,CUST-103,01/17/2024,-50.00,USD,completed,electronics
+ORD-004,CUST-104,2024-01-18,300.00,USD,SHIPPED,electronics
+ORD-005,CUST-105,2024-01-19,0.00,USD,completed,Electronics
+ORD-001,CUST-106,2024-01-20,175.00,USD,completed,clothing
+ORD-007,CUST-107,2024-13-01,90.00,USD,pending,clothing
+ORD-008,CUST-108,2024-01-22,500.00,EUR,completed,electronics
+ORD-009,CUST-109,2024-01-23,125.00,USD,unknown_status,clothing
+ORD-010,CUST-110,2024-01-24,275.00,USD,completed,CLOTHING
+ORD-011,CUST-111,2024-01-25,89.99,USD,cancelled,books
+ORD-012,CUST-112,2022-06-15,420.00,USD,shipped,home

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/lakefs_actions/validate_data.yaml
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/lakefs_actions/validate_data.yaml
@@ -1,0 +1,34 @@
+name: Data Quality Pre-Merge Gate
+on:
+  pre-merge:
+    branches:
+      - main
+
+hooks:
+  - id: check_validation_result
+    type: lua
+    properties:
+      script: |
+        local json = require("encoding/json")
+        local lakefs = require("lakefs")
+
+        -- Read the latest validation result written by the agent
+        local code, body = lakefs.get_object(
+          action.repository_id,
+          action.source_ref,
+          "validation/latest_result.json"
+        )
+
+        if code ~= 200 then
+          error("Pre-merge gate: could not find validation/latest_result.json on branch '"
+            .. action.source_ref .. "'. Run the agent loop before merging.")
+        end
+
+        local result = json.unmarshal(body)
+
+        if result["status"] ~= "passed" then
+          error("Pre-merge gate FAILED: latest validation did not pass. "
+            .. "Summary: " .. (result["summary"] or "unknown"))
+        end
+
+        print("Pre-merge gate PASSED: " .. (result["summary"] or "ok"))

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/prompts/repair_agent_system_prompt.md
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/prompts/repair_agent_system_prompt.md
@@ -1,0 +1,37 @@
+You are a data repair agent. Your task is to write Python code that fixes data quality issues in a CSV file.
+
+## Contract
+
+- Input: `/tmp/input.csv` (the dataset to repair)
+- Output: `/tmp/output.csv` (the repaired dataset, same columns, same column order)
+- Available libraries: `pandas`, `python-dateutil` (pre-installed)
+- Python version: 3.11
+
+## General repair strategy
+
+- Fix what can be deterministically corrected (normalise case, convert date formats where unambiguous)
+- Drop rows that cannot be repaired — never invent or fabricate values
+- Preserve all columns and their original order
+- Write output with the same header row
+
+## Critical pandas pitfalls — you MUST avoid these
+
+1. **NaN vs empty string**: `pandas.read_csv` reads empty CSV cells as `NaN` (float), NOT `''`.
+   - `df['customer_id'].str.strip() != ''` keeps NaN rows because `NaN != ''` is True in pandas.
+   - Always filter with: `df['customer_id'].notna() & (df['customer_id'].str.strip() != '')`
+   - Apply the same `.notna()` check to every required string column.
+
+2. **Boolean operator precedence**: In pandas, `&` binds tighter than `!=`, `==`, `>`.
+   - WRONG: `df['a'] != '' & df['b'] > 0`
+   - RIGHT: `(df['a'] != '') & (df['b'] > 0)`
+   - Always wrap every condition in its own parentheses.
+
+3. **String ops on NaN return NaN**: `df['col'].str.lower()` on a NaN value returns NaN, not a string.
+   - NaN cells after `.str.lower()` will not match any valid enum value — they will be dropped by the filter, which is correct.
+
+## Output requirements
+
+1. Return ONLY valid Python code — no markdown fences, no explanation, no comments
+2. The code must not crash on edge cases
+3. Write the repaired CSV to `/tmp/output.csv`
+4. Do not add or remove columns

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/pyproject.toml
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/pyproject.toml
@@ -1,0 +1,33 @@
+[project]
+name = "data-agent-demo"
+version = "0.2.0"
+description = "AI Data Agent: iterative LLM-driven data repair using E2B sandboxes, lakeFS versioned branches, and OpenAI"
+requires-python = ">=3.11"
+dependencies = [
+    "lakefs-e2b-common",
+    "e2b>=1.0.0",
+    "lakefs",
+    "boto3>=1.28.0",
+    "botocore>=1.31.0",
+    "pandas>=2.0.0",
+    "pyarrow>=12.0.0",
+    "python-dotenv>=1.0.0",
+    "rich>=13.0.0",
+    "openai>=1.0.0",
+    "python-dateutil>=2.8.0",
+    "pytest>=7.0.0",
+]
+
+[tool.uv.sources]
+lakefs-e2b-common = { workspace = true }
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agent_demo"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/scripts/run_demo.py
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/scripts/run_demo.py
@@ -1,0 +1,24 @@
+"""Convenience wrapper: run setup, upload sample data, then launch the agent loop."""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def run(cmd: list[str]) -> None:
+    """Run a command and exit if it fails."""
+    print(f"\n>>> {' '.join(cmd)}\n")
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+
+def main() -> None:
+    """Execute the full demo sequence end to end."""
+    run(["uv", "run", "python", "scripts/setup_lakefs_repo.py"])
+    run(["uv", "run", "python", "scripts/upload_sample_data.py"])
+    run(["uv", "run", "python", "-m", "agent_demo.main"])
+
+
+if __name__ == "__main__":
+    main()

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/scripts/setup_lakefs_repo.py
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/scripts/setup_lakefs_repo.py
@@ -5,10 +5,6 @@ import os
 import sys
 from pathlib import Path
 
-from dotenv import load_dotenv
-
-load_dotenv(Path(__file__).parent.parent / ".env")
-
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from agent_demo.config import load_config

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/scripts/setup_lakefs_repo.py
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/scripts/setup_lakefs_repo.py
@@ -1,0 +1,43 @@
+"""Set up the lakeFS repository and upload the pre-merge action."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from agent_demo.config import load_config
+from lakefs_e2b_common.lakefs_client import get_or_create_repo, make_client, upload_lakefsactions_yaml
+
+
+def main() -> None:
+    """Connect to lakeFS, create repo if needed, and upload the pre-merge action."""
+    config = load_config()
+
+    print(f"  Connecting to lakeFS at {config.lakefs_endpoint}...")
+    client = make_client(
+        config.lakefs_endpoint,
+        config.lakefs_access_key_id,
+        config.lakefs_secret_access_key,
+    )
+
+    print(f"  Ensuring repository '{config.lakefs_repository}' exists...")
+    repo = get_or_create_repo(client, config.lakefs_repository, config.lakefs_storage_namespace)
+    print(f"  Repository '{config.lakefs_repository}' is ready.")
+
+    yaml_path = Path(__file__).parent.parent / "lakefs_actions" / "validate_data.yaml"
+    yaml_content = yaml_path.read_text(encoding="utf-8")
+
+    print("  Uploading _lakefs_actions/validate_data.yaml to main branch...")
+    upload_lakefsactions_yaml(repo, yaml_content)
+    print("  Pre-merge action uploaded and committed.")
+    print()
+    print("  Setup complete.")
+    print(f"    lakeFS repo : {config.lakefs_repository}")
+    print(f"    Endpoint    : {config.lakefs_endpoint}")
+    print("    Action      : _lakefs_actions/validate_data.yaml (pre-merge gate)")
+
+
+if __name__ == "__main__":
+    main()

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/scripts/setup_lakefs_repo.py
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/scripts/setup_lakefs_repo.py
@@ -5,6 +5,10 @@ import os
 import sys
 from pathlib import Path
 
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from agent_demo.config import load_config

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/scripts/upload_sample_data.py
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/scripts/upload_sample_data.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from agent_demo.config import load_config

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/scripts/upload_sample_data.py
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/scripts/upload_sample_data.py
@@ -4,10 +4,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from dotenv import load_dotenv
-
-load_dotenv(Path(__file__).parent.parent / ".env")
-
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from agent_demo.config import load_config

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/scripts/upload_sample_data.py
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/scripts/upload_sample_data.py
@@ -1,0 +1,59 @@
+"""Upload the sample bad data CSV to lakeFS for the agent demo."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from agent_demo.config import load_config
+from lakefs_e2b_common.lakefs_client import commit, get_or_create_repo, make_client, write_object
+
+
+def main() -> None:
+    """Upload data/sample_bad_data.csv to raw/orders.csv on the main branch and commit."""
+    config = load_config()
+
+    print(f"  Connecting to lakeFS at {config.lakefs_endpoint}...")
+    client = make_client(
+        config.lakefs_endpoint,
+        config.lakefs_access_key_id,
+        config.lakefs_secret_access_key,
+    )
+
+    repo = get_or_create_repo(client, config.lakefs_repository, config.lakefs_storage_namespace)
+
+    data_path = Path(__file__).parent.parent / "data" / "sample_bad_data.csv"
+    csv_content = data_path.read_text(encoding="utf-8")
+    row_count = len(csv_content.strip().splitlines()) - 1  # subtract header
+
+    branch = repo.branch(config.lakefs_branch)
+    object_path = "raw/orders.csv"
+
+    print(f"  Uploading to {object_path} on branch '{config.lakefs_branch}'...")
+    write_object(branch, object_path, csv_content)
+
+    try:
+        commit_id = commit(
+            branch,
+            message="Add sample bad data for agent demo",
+            metadata={"source": "upload_sample_data.py", "rows": str(row_count)},
+        )
+        commit_label = commit_id
+    except Exception as exc:
+        if "no changes" in str(exc).lower():
+            commit_label = "(already up to date — no new commit needed)"
+        else:
+            raise
+
+    print("  Upload complete.")
+    print()
+    print("  Done.")
+    print(f"    lakeFS repo   : {config.lakefs_repository}")
+    print(f"    Branch        : {config.lakefs_branch}")
+    print(f"    Object        : {object_path}  ({row_count} data rows)")
+    print(f"    Commit        : {commit_label}")
+
+
+if __name__ == "__main__":
+    main()

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/agent_loop.py
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/agent_loop.py
@@ -1,0 +1,164 @@
+"""Main iterative repair loop: validate → generate → run in E2B → commit → repeat."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+import lakefs
+
+from agent_demo.config import Config
+from agent_demo.e2b_runner import run_repair
+from lakefs_e2b_common.lakefs_client import commit, read_object, write_object
+from agent_demo.openai_agent import AttemptContext, generate_repair_code
+from agent_demo.validation import PHASE_NAMES, ValidationFailure, ValidationResult, validate
+
+
+@dataclass
+class AgentRunResult:
+    branch_name: str
+    passed: bool
+    total_attempts: int
+    attempts: list[dict]
+    final_commit_id: str | None
+    final_validation: ValidationResult | None
+
+
+def _divider() -> None:
+    print("─" * 60)
+
+
+def run(
+    config: Config,
+    lakefs_client_obj,
+    repo: lakefs.Repository,
+    branch_name: str,
+) -> AgentRunResult:
+    """Run the progressive repair loop, advancing through validation phases until all pass."""
+    branch = repo.branch(branch_name)
+    current_csv = read_object(branch, "raw/orders.csv")
+
+    previous_attempts: list[AttemptContext] = []
+    attempt_summaries: list[dict] = []
+    final_commit_id: str | None = None
+    final_validation: ValidationResult | None = None
+    passed = False
+
+    for attempt in range(1, config.max_attempts + 1):
+        _divider()
+        print(f"  Attempt {attempt}/{config.max_attempts}")
+        _divider()
+
+        validation = validate(current_csv)
+
+        if validation.passed:
+            passed = True
+            final_validation = validation
+            print(f"  Validation: PASSED — {validation.summary}")
+            break
+
+        phase = validation.failed_phase
+        phase_name = PHASE_NAMES[phase]
+        print(f"  Phase {phase} ({phase_name}): {len(validation.failures)} failure(s)")
+        for f in validation.failures:
+            print(f"    • {f.rule}: rows {f.affected_rows}")
+
+        print(f"  Generating repair code via OpenAI ({config.openai_model})...")
+        repair_code = generate_repair_code(
+            openai_api_key=config.openai_api_key,
+            model=config.openai_model,
+            current_csv=current_csv,
+            current_phase=phase,
+            validation_failures=validation.failures,
+            previous_attempts=previous_attempts,
+        )
+
+        print(f"  Running repair in E2B sandbox...")
+        sandbox_result = run_repair(current_csv, repair_code, config.e2b_api_key)
+        print(f"  Sandbox: {sandbox_result.sandbox_id}")
+
+        if sandbox_result.success and sandbox_result.output_csv:
+            repair_validation = validate(sandbox_result.output_csv)
+            repaired_csv: str | None = sandbox_result.output_csv
+        else:
+            error_parts = [sandbox_result.error or "sandbox execution failed"]
+            if sandbox_result.stderr.strip():
+                error_parts.append(
+                    f"Command exited with code {sandbox_result.exit_code} and error:\n{sandbox_result.stderr.strip()}"
+                )
+            repair_validation = ValidationResult(
+                passed=False,
+                failures=[ValidationFailure("execution_error", "\n".join(error_parts), [])],
+                row_count=0,
+                failed_phase=phase,
+            )
+            repaired_csv = None
+
+        status_str = "passed" if repair_validation.passed else "failed"
+        result_phase = repair_validation.failed_phase
+        print(
+            f"  Result: {'PASSED' if repair_validation.passed else f'phase {result_phase} still failing'}"
+            f" — {repair_validation.summary}"
+        )
+
+        if repaired_csv:
+            write_object(branch, "curated/repaired_orders.csv", repaired_csv)
+
+        validation_json = json.dumps(repair_validation.to_dict(), indent=2)
+        write_object(branch, "validation/latest_result.json", validation_json)
+        write_object(branch, f"validation/attempt_{attempt}_result.json", validation_json)
+        write_object(branch, f"code/repair_attempt_{attempt}.py", repair_code)
+
+        metadata: dict[str, str] = {
+            "attempt": str(attempt),
+            "target_phase": str(phase),
+            "status": status_str,
+            "sandbox_id": sandbox_result.sandbox_id,
+            "model": config.openai_model,
+            "validation_summary": repair_validation.summary,
+        }
+        if config.e2b_team and sandbox_result.sandbox_id != "unknown":
+            sandbox_url = (
+                f"https://e2b.dev/dashboard/{config.e2b_team}"
+                f"/sandboxes/{sandbox_result.sandbox_id}/monitoring"
+            )
+            metadata["::lakefs::E2B Sandbox::url[url:ui]"] = sandbox_url
+
+        commit_id = commit(branch, f"Attempt {attempt} — phase {phase} ({PHASE_NAMES[phase]}): {status_str}", metadata)
+        print(f"  Committed: {commit_id[:12]}")
+
+        attempt_summaries.append({
+            "attempt": attempt,
+            "target_phase": phase,
+            "phase_name": PHASE_NAMES[phase],
+            "status": status_str,
+            "commit_id": commit_id,
+            "sandbox_id": sandbox_result.sandbox_id,
+            "validation_summary": repair_validation.summary,
+        })
+
+        previous_attempts.append(AttemptContext(
+            attempt=attempt,
+            repair_code=repair_code,
+            validation_result=repair_validation,
+            e2b_stdout=sandbox_result.stdout,
+            e2b_stderr=sandbox_result.stderr,
+            e2b_exit_code=sandbox_result.exit_code,
+        ))
+        final_commit_id = commit_id
+        final_validation = repair_validation
+
+        if repair_validation.passed:
+            passed = True
+            break
+
+        if repaired_csv:
+            current_csv = repaired_csv
+
+    return AgentRunResult(
+        branch_name=branch_name,
+        passed=passed,
+        total_attempts=len(attempt_summaries),
+        attempts=attempt_summaries,
+        final_commit_id=final_commit_id,
+        final_validation=final_validation,
+    )

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/config.py
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/config.py
@@ -1,0 +1,38 @@
+"""Load and validate configuration from environment variables."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lakefs_e2b_common.env import optional, optional_int, require
+
+
+@dataclass
+class Config:
+    openai_api_key: str
+    openai_model: str
+    e2b_api_key: str
+    e2b_team: str        # optional — enables sandbox links in lakeFS commit metadata
+    lakefs_endpoint: str
+    lakefs_access_key_id: str
+    lakefs_secret_access_key: str
+    lakefs_repository: str
+    lakefs_storage_namespace: str
+    lakefs_branch: str
+    max_attempts: int
+
+
+def load_config() -> Config:
+    """Read config from environment, raising SystemExit for missing required vars."""
+    return Config(
+        openai_api_key=require("OPENAI_API_KEY"),
+        openai_model=optional("OPENAI_MODEL", "gpt-4o-mini"),
+        e2b_api_key=require("E2B_API_KEY"),
+        e2b_team=optional("E2B_TEAM"),
+        lakefs_endpoint=require("LAKEFS_ENDPOINT"),
+        lakefs_access_key_id=require("LAKEFS_ACCESS_KEY_ID"),
+        lakefs_secret_access_key=require("LAKEFS_SECRET_ACCESS_KEY"),
+        lakefs_repository=require("LAKEFS_REPOSITORY"),
+        lakefs_storage_namespace=optional("LAKEFS_STORAGE_NAMESPACE"),
+        lakefs_branch=optional("LAKEFS_BRANCH", "main"),
+        max_attempts=optional_int("MAX_ATTEMPTS", 5),
+    )

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/e2b_runner.py
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/e2b_runner.py
@@ -1,0 +1,81 @@
+"""Run repair code in an E2B cloud sandbox."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from e2b import Sandbox
+
+
+@dataclass
+class SandboxResult:
+    success: bool
+    sandbox_id: str
+    output_csv: str | None
+    stdout: str
+    stderr: str
+    exit_code: int
+    error: str | None
+
+
+def run_repair(input_csv: str, repair_code: str, e2b_api_key: str) -> SandboxResult:
+    """Upload input CSV and repair code to an E2B sandbox, run it, and return the result."""
+    sandbox = None
+    try:
+        sandbox = Sandbox.create(api_key=e2b_api_key)
+        sandbox_id = sandbox.sandbox_id
+
+        sandbox.files.write("/tmp/input.csv", input_csv)
+        sandbox.files.write("/tmp/repair_code.py", repair_code)
+
+        pip_result = sandbox.commands.run(
+            "pip install -q pandas python-dateutil", timeout=120
+        )
+
+        run_result = sandbox.commands.run(
+            "python /tmp/repair_code.py", timeout=60
+        )
+
+        stdout = (run_result.stdout or "") + (pip_result.stdout or "")
+        stderr = (run_result.stderr or "") + (pip_result.stderr or "")
+        exit_code = run_result.exit_code
+
+        if exit_code != 0:
+            return SandboxResult(
+                success=False,
+                sandbox_id=sandbox_id,
+                output_csv=None,
+                stdout=stdout,
+                stderr=stderr,
+                exit_code=exit_code,
+                error=f"Repair script exited with code {exit_code}",
+            )
+
+        output_csv = sandbox.files.read("/tmp/output.csv", format="text")
+
+        return SandboxResult(
+            success=True,
+            sandbox_id=sandbox_id,
+            output_csv=output_csv,
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=exit_code,
+            error=None,
+        )
+
+    except Exception as exc:
+        sandbox_id = sandbox.sandbox_id if sandbox else "unknown"
+        return SandboxResult(
+            success=False,
+            sandbox_id=sandbox_id,
+            output_csv=None,
+            stdout="",
+            stderr="",
+            exit_code=-1,
+            error=str(exc),
+        )
+    finally:
+        if sandbox is not None:
+            try:
+                sandbox.kill()
+            except Exception:
+                pass

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/main.py
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/main.py
@@ -4,11 +4,6 @@ from __future__ import annotations
 import argparse
 import sys
 from datetime import datetime
-from pathlib import Path
-
-from dotenv import load_dotenv
-
-load_dotenv(Path(__file__).parent.parent.parent.parent / ".env")
 
 from agent_demo.agent_loop import run
 from agent_demo.config import load_config

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/main.py
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/main.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 import argparse
 import sys
 from datetime import datetime
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent.parent.parent.parent / ".env")
 
 from agent_demo.agent_loop import run
 from agent_demo.config import load_config

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/main.py
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/main.py
@@ -1,0 +1,85 @@
+"""Entry point for the AI Data Agent demo."""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+
+from agent_demo.agent_loop import run
+from agent_demo.config import load_config
+from lakefs_e2b_common.lakefs_client import (
+    create_branch,
+    get_or_create_repo,
+    make_client,
+    merge_branch,
+)
+from agent_demo.reporting import print_final_report, save_report
+
+
+def main() -> None:
+    """Parse arguments, run the agent loop, and optionally merge the result."""
+    parser = argparse.ArgumentParser(
+        description="AI Data Agent: iterative LLM-driven data repair with E2B + lakeFS"
+    )
+    parser.add_argument(
+        "--no-merge",
+        action="store_true",
+        help="Do not auto-merge into main even if validation passes",
+    )
+    parser.add_argument(
+        "--max-attempts",
+        type=int,
+        default=None,
+        help="Override the maximum number of repair attempts",
+    )
+    parser.add_argument(
+        "--branch",
+        default=None,
+        help="Source branch to read data from (default: value of LAKEFS_BRANCH or 'main')",
+    )
+    args = parser.parse_args()
+
+    config = load_config()
+
+    if args.max_attempts is not None:
+        config.max_attempts = args.max_attempts
+
+    source_branch = args.branch or config.lakefs_branch
+
+    client = make_client(
+        config.lakefs_endpoint,
+        config.lakefs_access_key_id,
+        config.lakefs_secret_access_key,
+    )
+    repo = get_or_create_repo(client, config.lakefs_repository, config.lakefs_storage_namespace)
+
+    timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    feature_branch_name = f"agent-run-{timestamp}"
+
+    print(f"  Creating branch '{feature_branch_name}' from '{source_branch}'...")
+    create_branch(repo, feature_branch_name, source_branch)
+    print(f"  Branch created.")
+
+    result = run(config, client, repo, feature_branch_name)
+
+    print_final_report(result, config)
+
+    report_path = f"outputs/report-{timestamp}.json"
+    save_report(result, report_path)
+    print(f"  Report saved to {report_path}")
+
+    if result.passed and not args.no_merge:
+        print(f"\n  Merging '{feature_branch_name}' into '{source_branch}'...")
+        feature_branch = repo.branch(feature_branch_name)
+        main_branch = repo.branch(source_branch)
+        merge_ref = merge_branch(feature_branch, main_branch)
+        print(f"  Merged successfully. Merge ref: {merge_ref}")
+    elif not result.passed:
+        print(
+            f"\n  Branch not merged. Inspect with:\n"
+            f"  uv run python -m agent_demo.main --inspect {feature_branch_name}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/openai_agent.py
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/openai_agent.py
@@ -1,0 +1,87 @@
+"""OpenAI-powered repair code generator."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from openai import OpenAI
+
+from agent_demo.validation import PHASE_RULES, ValidationFailure, ValidationResult
+
+
+@dataclass
+class AttemptContext:
+    attempt: int
+    repair_code: str
+    validation_result: ValidationResult
+    e2b_stdout: str
+    e2b_stderr: str
+    e2b_exit_code: int
+
+
+def _load_system_prompt() -> str:
+    """Read the base system prompt (contract + pandas pitfalls, no phase-specific rules)."""
+    prompt_path = Path(__file__).parent.parent.parent / "prompts" / "repair_agent_system_prompt.md"
+    return prompt_path.read_text(encoding="utf-8")
+
+
+def _strip_code_fences(text: str) -> str:
+    """Remove markdown code fences if present."""
+    text = text.strip()
+    match = re.match(r"^```(?:python)?\n(.*?)```$", text, re.DOTALL)
+    return match.group(1).strip() if match else text
+
+
+def generate_repair_code(
+    openai_api_key: str,
+    model: str,
+    current_csv: str,
+    current_phase: int,
+    validation_failures: list[ValidationFailure],
+    previous_attempts: list[AttemptContext],
+) -> str:
+    """Generate Python repair code targeting the failures in current_phase."""
+    system_prompt = _load_system_prompt()
+
+    csv_lines = current_csv.splitlines()
+    csv_display = "\n".join(csv_lines[:51]) + ("\n... truncated" if len(csv_lines) > 51 else "")
+
+    failure_lines = [
+        f"- Rule: {f.rule}\n  Description: {f.description}\n  Affected rows (1-based): {f.affected_rows}"
+        for f in validation_failures
+    ]
+
+    user_parts = [
+        f"## Current Validation Phase\n{PHASE_RULES[current_phase]}",
+        "## Current Data\n```csv\n" + csv_display + "\n```",
+        "## Failures to fix\n" + "\n".join(failure_lines),
+    ]
+
+    if previous_attempts:
+        parts = []
+        for ctx in previous_attempts:
+            p = (
+                f"### Attempt {ctx.attempt} (phase {ctx.validation_result.failed_phase})\n"
+                f"**Result:** {ctx.validation_result.summary}\n"
+                f"**Exit code:** {ctx.e2b_exit_code}\n"
+            )
+            if ctx.e2b_stderr.strip():
+                p += f"**Stderr:**\n```\n{ctx.e2b_stderr.strip()}\n```\n"
+            p += f"**Code used:**\n```python\n{ctx.repair_code}\n```"
+            parts.append(p)
+        user_parts.append("## Previous attempts\n" + "\n\n".join(parts))
+
+    user_message = "\n\n".join(user_parts)
+    user_message += "\n\nWrite repair code that fixes all failures listed above."
+
+    client = OpenAI(api_key=openai_api_key)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_message},
+        ],
+    )
+
+    return _strip_code_fences(response.choices[0].message.content or "")

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/reporting.py
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/reporting.py
@@ -1,0 +1,66 @@
+"""Final report printing and saving utilities."""
+from __future__ import annotations
+
+import json
+import os
+
+from agent_demo.agent_loop import AgentRunResult
+from agent_demo.config import Config
+
+
+def print_final_report(result: AgentRunResult, config: Config) -> None:
+    """Print a human-readable summary of the agent run to stdout."""
+    divider = "─" * 60
+    print(f"\n{divider}")
+    print("  Final Report")
+    print(divider)
+    print(f"  Branch      : {result.branch_name}")
+    print(f"  Total attempts: {result.total_attempts}")
+    print(f"  Outcome     : {'PASSED' if result.passed else 'FAILED'}")
+    print()
+
+    for a in result.attempts:
+        status_label = "PASS" if a["status"] == "passed" else "FAIL"
+        print(
+            f"  Attempt {a['attempt']}: [{status_label}]  "
+            f"commit={a['commit_id'][:12]}  "
+            f"{a['validation_summary']}"
+        )
+
+    if result.passed and result.final_commit_id:
+        print()
+        print(f"  Final commit: {result.final_commit_id}")
+        print(
+            f"  Merge with : uv run python -m agent_demo.main"
+            f" --branch {config.lakefs_branch}"
+        )
+        print(
+            f"  lakeFS UI  : {config.lakefs_endpoint}/repositories/"
+            f"{config.lakefs_repository}/objects?ref={result.branch_name}"
+        )
+    else:
+        print()
+        print(f"  All {config.max_attempts} attempts failed.")
+        print(f"  Inspect branch: {result.branch_name}")
+        print(
+            f"  lakeFS UI  : {config.lakefs_endpoint}/repositories/"
+            f"{config.lakefs_repository}/objects?ref={result.branch_name}"
+        )
+    print(divider)
+
+
+def save_report(result: AgentRunResult, output_path: str) -> None:
+    """Save the run result as JSON to output_path."""
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    data = {
+        "branch_name": result.branch_name,
+        "passed": result.passed,
+        "total_attempts": result.total_attempts,
+        "attempts": result.attempts,
+        "final_commit_id": result.final_commit_id,
+        "final_validation": (
+            result.final_validation.to_dict() if result.final_validation else None
+        ),
+    }
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)

--- a/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/validation.py
+++ b/01_standalone_examples/e2b/usecases/02-three-phase-repair/src/agent_demo/validation.py
@@ -1,0 +1,227 @@
+"""Three-phase progressive CSV validation — no external dependencies."""
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+VALID_STATUSES = {"completed", "pending", "shipped", "cancelled"}
+VALID_CATEGORIES = {"electronics", "clothing", "books", "home", "sports"}
+
+AMOUNT_CEILING = 350.00
+MIN_ORDER_YEAR = 2023
+
+PHASE_NAMES = {
+    1: "Structural Integrity",
+    2: "Format & Value Conformance",
+    3: "Business Rules",
+}
+
+PHASE_RULES = {
+    1: """Phase 1 — Structural Integrity:
+  - order_id: required (not empty), must be unique across all rows
+  - customer_id: required (not empty, not whitespace, not NaN/null)
+  - amount: must be present and parseable as a number
+  Fix these issues first. Later phases check format, values, and business rules.""",
+
+    2: """Phase 2 — Format & Value Conformance:
+  - order_date: must be YYYY-MM-DD format and a valid calendar date
+  - amount: must be strictly greater than 0
+  - currency: must be exactly "USD"
+  - status: must be one of: completed, pending, shipped, cancelled (all lowercase)
+  - product_category: must be one of: electronics, clothing, books, home, sports (all lowercase)
+  Normalize case where possible; drop rows with values that cannot be repaired.""",
+
+    3: f"""Phase 3 — Business Rules:
+  - order_date year must be {MIN_ORDER_YEAR} or later (orders older than {MIN_ORDER_YEAR} are stale and excluded)
+  - amount must not exceed {AMOUNT_CEILING} (orders above this threshold require manual review and must be excluded)
+  Drop rows that violate these constraints — do not modify amounts or dates.""",
+}
+
+
+@dataclass
+class ValidationFailure:
+    rule: str
+    description: str
+    affected_rows: list[int]
+
+
+@dataclass
+class ValidationResult:
+    passed: bool
+    failures: list[ValidationFailure]
+    row_count: int
+    failed_phase: int  # 0 = all phases passed; 1/2/3 = first phase that failed
+
+    @property
+    def phase_name(self) -> str:
+        """Human-readable name of the failing phase."""
+        return PHASE_NAMES.get(self.failed_phase, "All phases passed") if self.failed_phase else "All phases passed"
+
+    @property
+    def summary(self) -> str:
+        """One-line human-readable summary."""
+        if self.passed:
+            return f"{self.row_count} rows, all phases passed"
+        return (
+            f"{self.row_count} rows, phase {self.failed_phase} ({self.phase_name}) failed — "
+            + "; ".join(f.rule for f in self.failures)
+        )
+
+    def to_dict(self) -> dict:
+        """Serialise to a plain dict for JSON output."""
+        return {
+            "status": "passed" if self.passed else "failed",
+            "failed_phase": self.failed_phase,
+            "phase_name": self.phase_name,
+            "row_count": self.row_count,
+            "summary": self.summary,
+            "failures": [
+                {
+                    "rule": f.rule,
+                    "description": f.description,
+                    "affected_rows": f.affected_rows,
+                }
+                for f in self.failures
+            ],
+        }
+
+
+def _is_valid_date(value: str) -> bool:
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+        return True
+    except ValueError:
+        return False
+
+
+def _phase1(rows: list[dict]) -> list[ValidationFailure]:
+    """Structural: required fields, uniqueness, amount parseability."""
+    failures: list[ValidationFailure] = []
+
+    missing_order_id = [i + 1 for i, r in enumerate(rows) if not r.get("order_id", "").strip()]
+    if missing_order_id:
+        failures.append(ValidationFailure("order_id_required", "order_id is missing or empty", missing_order_id))
+
+    seen: dict[str, int] = {}
+    duplicates: list[int] = []
+    for i, r in enumerate(rows):
+        oid = r.get("order_id", "").strip()
+        if oid:
+            if oid in seen:
+                duplicates.append(i + 1)
+            else:
+                seen[oid] = i + 1
+    if duplicates:
+        failures.append(ValidationFailure("order_id_unique", "Duplicate order_id values found", duplicates))
+
+    missing_customer = [i + 1 for i, r in enumerate(rows) if not r.get("customer_id", "").strip()]
+    if missing_customer:
+        failures.append(ValidationFailure("customer_id_required", "customer_id is missing or empty", missing_customer))
+
+    bad_amount = []
+    for i, r in enumerate(rows):
+        try:
+            float(r.get("amount", "").strip())
+        except (ValueError, AttributeError):
+            bad_amount.append(i + 1)
+    if bad_amount:
+        failures.append(ValidationFailure("amount_parseable", "amount must be a valid number", bad_amount))
+
+    return failures
+
+
+def _phase2(rows: list[dict]) -> list[ValidationFailure]:
+    """Format & values: date format, positive amount, currency, enumerations."""
+    failures: list[ValidationFailure] = []
+
+    bad_date = [i + 1 for i, r in enumerate(rows) if not _is_valid_date(r.get("order_date", "").strip())]
+    if bad_date:
+        failures.append(ValidationFailure("order_date_format", "order_date must be a valid YYYY-MM-DD date", bad_date))
+
+    bad_amount = []
+    for i, r in enumerate(rows):
+        try:
+            if float(r.get("amount", "").strip()) <= 0:
+                bad_amount.append(i + 1)
+        except (ValueError, AttributeError):
+            pass  # already caught in phase 1
+    if bad_amount:
+        failures.append(ValidationFailure("amount_positive", "amount must be strictly greater than 0", bad_amount))
+
+    bad_currency = [i + 1 for i, r in enumerate(rows) if r.get("currency", "").strip() != "USD"]
+    if bad_currency:
+        failures.append(ValidationFailure("currency_usd", "currency must be exactly 'USD'", bad_currency))
+
+    bad_status = [i + 1 for i, r in enumerate(rows) if r.get("status", "").strip() not in VALID_STATUSES]
+    if bad_status:
+        failures.append(
+            ValidationFailure("status_valid", f"status must be one of: {', '.join(sorted(VALID_STATUSES))}", bad_status)
+        )
+
+    bad_category = [i + 1 for i, r in enumerate(rows) if r.get("product_category", "").strip() not in VALID_CATEGORIES]
+    if bad_category:
+        failures.append(
+            ValidationFailure(
+                "product_category_valid",
+                f"product_category must be one of: {', '.join(sorted(VALID_CATEGORIES))}",
+                bad_category,
+            )
+        )
+
+    return failures
+
+
+def _phase3(rows: list[dict]) -> list[ValidationFailure]:
+    """Business rules: date recency, amount ceiling."""
+    failures: list[ValidationFailure] = []
+
+    stale_rows = []
+    for i, r in enumerate(rows):
+        date_str = r.get("order_date", "").strip()
+        if _is_valid_date(date_str):
+            year = int(date_str[:4])
+            if year < MIN_ORDER_YEAR:
+                stale_rows.append(i + 1)
+    if stale_rows:
+        failures.append(
+            ValidationFailure(
+                "date_recency",
+                f"order_date year must be {MIN_ORDER_YEAR} or later — stale orders are excluded",
+                stale_rows,
+            )
+        )
+
+    over_ceiling = []
+    for i, r in enumerate(rows):
+        try:
+            if float(r.get("amount", "").strip()) > AMOUNT_CEILING:
+                over_ceiling.append(i + 1)
+        except (ValueError, AttributeError):
+            pass
+    if over_ceiling:
+        failures.append(
+            ValidationFailure(
+                "amount_ceiling",
+                f"amount must not exceed {AMOUNT_CEILING} — orders above this require manual review",
+                over_ceiling,
+            )
+        )
+
+    return failures
+
+
+def validate(csv_text: str) -> ValidationResult:
+    """Run all three phases in order, stopping at the first failure."""
+    reader = csv.DictReader(io.StringIO(csv_text))
+    rows = list(reader)
+    row_count = len(rows)
+
+    for phase, check_fn in [(1, _phase1), (2, _phase2), (3, _phase3)]:
+        failures = check_fn(rows)
+        if failures:
+            return ValidationResult(passed=False, failures=failures, row_count=row_count, failed_phase=phase)
+
+    return ValidationResult(passed=True, failures=[], row_count=row_count, failed_phase=0)

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/.env.example
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/.env.example
@@ -1,0 +1,23 @@
+# === lakeFS Cloud (Enterprise — required for lakeFS Mount / everest) ===
+LAKEFS_ENDPOINT=https://your-org.region.lakefscloud.io
+LAKEFS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+LAKEFS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+LAKEFS_REPOSITORY=receipts-ledger-demo
+# Optional — used to auto-create the repo if it doesn't exist:
+LAKEFS_STORAGE_NAMESPACE=s3://your-bucket/receipts-ledger-demo/
+LAKEFS_BRANCH=main
+
+# === E2B ===
+E2B_API_KEY=e2b_...
+E2B_TEAM=your-e2b-team-slug   # optional — adds a sandbox link in lakeFS commit metadata
+# Optional: a prebaked template (see template/). Leave EMPTY to use the default sandbox
+# with a one-time runtime install of everest + fuse + deps (works out of the box).
+E2B_TEMPLATE=
+
+# === Vision model (Phase 2 multimodal extraction) ===
+OPENAI_API_KEY=sk-...
+OPENAI_MODEL=gpt-4o
+
+# === Run control ===
+# Optional: pin "today" for reproducible date checks (e.g. the future-dated reject). Empty = real today.
+DEMO_TODAY=

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/README.md
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/README.md
@@ -1,0 +1,240 @@
+# Use Case 3 — Receipts → Clean Ledger (lakeFS Mount)
+
+> Part of [**Agentic Data Patterns: E2B + lakeFS**](../../README.md). See the repo root for the full set of use cases.
+
+> An AI agent turns a messy dump of receipt & invoice **images and PDFs** into a
+> validated ledger — iteratively, in an E2B sandbox, working directly on a **lakeFS
+> branch mounted as a filesystem** — and only a clean ledger is allowed to merge to `main`.
+
+---
+
+## What makes this one different
+
+Use cases 1 and 2 pass data through the lakeFS **Python SDK** (read object → process →
+write object → commit). This one uses **lakeFS Mount (`everest`)**, which exposes a branch
+as a real filesystem path.
+
+That matters because **most of what agents actually do happens on a filesystem.** The agent
+here never imports the lakeFS SDK and never knows about S3 — it does plain file I/O on
+`/home/user/mnt/...`:
+
+```python
+for path in glob("/home/user/mnt/inbox/*"):   # ordinary filesystem
+    png = load_image_png(path)                 # ordinary file read (PDF → raster)
+    fields = vision_extract(png)               # gpt-4o multimodal
+    append_row("/home/user/mnt/ledger.csv", fields)   # ordinary file write
+```
+
+Versioning happens out-of-band: after each phase the host runs `everest commit`, which
+snapshots the mounted changes back to the lakeFS branch (via a temporary `everest-w-*`
+write branch that is merged into the source branch).
+
+---
+
+## Demo story
+
+A chaotic `inbox/` is uploaded to a lakeFS repo — receipts across **many formats**
+(`jpg`, `png`, `webp`, `bmp`, `tiff`, single- and multi-page `pdf`), plus duplicates, a
+corrupt file, a non-receipt photo, an unsupported `.txt`, and several invalid invoices. The
+agent works in **three progressive phases**, each committed to its branch:
+
+| Phase | What it does | What it catches in the sample set |
+|-------|--------------|------------------------------------|
+| **1 — Triage (structural)** | hash-dedupe, drop corrupt/unreadable & unsupported files, drop non-receipts (vision `is_receipt`) | a corrupt file, an exact duplicate, a beach photo, a `.txt` note |
+| **2 — Extract (multimodal)** | gpt-4o reads each kept file → `{vendor, date, invoice_no, currency, line_items, total}` cached as sidecars → `ledger_draft` (multi-page PDFs are page-stacked so a total on page 2 is read) | (the low-contrast receipt still extracts) |
+| **3 — Validate (business rules)** | `total == sum(items)`, date sane & not future, currency = USD, unique invoice no, total ≤ \$500 cap | math mismatch, future-dated, EUR, duplicate invoice #, over-cap |
+
+A clean run produces **4 accepted / 5 rejected / 4 dropped**, written to `ledger.csv` and
+`rejects.csv`. A lakeFS **pre-merge Action** (`lakefs_actions/validate_ledger.yaml`) gates
+`main` on `validation/latest_result.json` — so a half-processed or invalid ledger physically
+cannot be promoted, regardless of who triggers the merge.
+
+---
+
+## Architecture
+
+```
+                 ┌─────────────────────┐
+                 │  OpenAI gpt-4o      │  (called from inside the sandbox)
+                 │  vision extraction  │
+                 └─────────┬───────────┘
+                           │ per-file JSON
+                           ▼
+┌──────────────────────────────────────────────────────────┐
+│            E2B Sandbox  (mount + agent run as root)        │
+│   everest mount lakefs://repo/<branch>/ /home/user/mnt     │
+│                       --protocol fuse --write-mode         │
+│                                                            │
+│   inbox/*.{jpg,png,webp,bmp,tiff,pdf}   (plain file I/O)   │
+│   archive/**                (large; never opened → lazy)   │
+│   sidecars/<file>.json      (extraction cache)             │
+│   ledger.csv / rejects.csv  (agent writes)                 │
+│   validation/latest_result.json                            │
+│                                                            │
+│   host runs each phase, then:  everest commit -m "Phase N" │
+└───────────────────────────┬────────────────────────────────┘
+                            │ commits land on the branch
+                            ▼
+                 ┌──────────────────────┐
+                 │      lakeFS          │
+                 │  • agent branch      │
+                 │  • pre-merge gate    │  ← validation status == "passed"
+                 └──────────┬───────────┘
+                            │ merge only when the gate passes
+                            ▼
+                         main branch
+```
+
+The **host** (`orchestrator.py`) owns lakeFS branch creation, the per-phase `everest commit`,
+and the final merge. The **agent** (`agent_runner.py`, run inside the sandbox) owns all the
+work on the mounted files. Reads are **lazy** — a file's bytes are fetched from the object
+store only when the agent opens it, straight from storage (the lakeFS server isn't in the
+data path).
+
+---
+
+## Lazy fetch — bring a big dataset, pay only for what you open
+
+Because reads are lazy, you can mount a branch holding a huge dataset and the agent only
+fetches the handful of files it actually opens. `scripts/upload_archive.py` uploads a large
+`archive/` of decoy files (tunable) that the agent never touches:
+
+```bash
+# default ~250 MB; scale freely (one-time, bandwidth-bound)
+ARCHIVE_FILES=5000 ARCHIVE_SIZE_KB=1024 uv run python scripts/upload_archive.py   # ~5 GB
+```
+
+Measured with a 5 GB / 5,000-file `archive/` present:
+
+| Metric | Value |
+|---|---|
+| Mounted (branch, apparent) | **4.9 GB / 5,013 files** |
+| everest local cache after the run | **~16 MB** (branch metadata for 5,000 files + the agent's inbox reads) |
+| `archive/` content (4.9 GB) | **never fetched** |
+
+Mounting is near-instant regardless of branch size; only the agent's inbox reads transfer. The
+local cache tracks **file count** (metadata), not archive size — bump `archive/` to tens of GB and
+the fetched content stays flat.
+
+---
+
+## Prerequisites
+
+- A **lakeFS instance with Mount (`everest`) enabled** — sign up for [lakeFS Cloud](https://lakefs.cloud/) (Mount is available on lakeFS Cloud / Enterprise).
+- An **E2B** account — sign up at [e2b.dev](https://e2b.dev) and get your key from the [dashboard](https://e2b.dev/dashboard) (`E2B_API_KEY`).
+- An **OpenAI** key (`gpt-4o` for vision).
+- The **everest Linux x86_64 binary** at `build/bin/everest`. `everest` is the lakeFS
+  **Enterprise** Mount binary — it is **not redistributable**, so it is gitignored and not
+  shipped with this sample. Download it yourself from the lakeFS changelog (or
+  [contact lakeFS](https://lakefs.io/contact-sales/)) and extract:
+  ```bash
+  curl -fsSL -o everest.tgz https://artifacts.lakefs.io/everest/0.9.2/everest_0.9.2_Linux_x86_64.tar.gz
+  mkdir -p build/bin && tar -xzf everest.tgz -C build/bin
+  ```
+
+Copy `.env.example` to `.env` and fill it in. `.env` is gitignored.
+
+---
+
+## Quickstart
+
+```bash
+# from the repo root: install the workspace
+uv sync
+cd usecases/03-mount-receipts
+cp .env.example .env        # fill in lakeFS + E2B + OpenAI
+
+# 1) create the repo (if needed) + install the pre-merge gate on main
+uv run python scripts/setup_lakefs_repo.py
+# 2) generate the messy receipt inbox and upload it to main/inbox/
+uv run python scripts/upload_sample_data.py
+# 3) (optional) upload a large archive/ to show lazy fetch
+uv run python scripts/upload_archive.py
+# 4) run the agent (branch → sandbox → mount → 3 phases → commit → gate → merge)
+uv run python -m mount_receipts.main
+```
+
+Or steps 1–2 + run at once: `uv run python scripts/run_demo.py`.
+
+Run the unit tests (no live services): `uv run pytest`.
+
+---
+
+## Inspecting results
+
+```bash
+lakectl fs cat   lakefs://<repo>/main/ledger.csv      # 4 accepted receipts
+lakectl fs cat   lakefs://<repo>/main/rejects.csv     # 9 dropped/rejected, with reasons
+lakectl log      lakefs://<repo>/<agent-branch>       # the three progressive phase commits
+```
+
+**E2B ↔ lakeFS link.** `everest commit` can't attach lakeFS commit metadata, so after the
+phase commits the host writes a final **"Agent run manifest"** commit carrying a clickable
+**E2B Sandbox** link (`::lakefs::E2B Sandbox::url[url:ui]` metadata, shown when `E2B_TEAM` is
+set) plus a `run_manifest.json`. From any merged ledger you can jump straight to the exact
+sandbox that produced it — the audit trail spans both systems.
+
+**See the gate block a bad ledger:** create a branch, write a `validation/latest_result.json`
+with `"status":"failed"`, commit, and `lakectl merge` it into `main` — the pre-merge Action
+rejects it with `412 Precondition Failed`.
+
+### Browse the live mount in the E2B dashboard
+
+Run with `--keep-sandbox` to leave the sandbox (and its mount) alive, then open the sandbox's
+**Filesystem** tab and navigate to `/home/user/mnt` to see the lakeFS branch as live files:
+
+```bash
+uv run python -m mount_receipts.main --keep-sandbox   # report prints the E2B sandbox link
+```
+
+**Why the agent runs as root:** E2B's `envd` (which serves the dashboard Filesystem tab) runs
+as root, but a FUSE mount is only visible to the user that mounted it, and `everest` has no
+`allow_other` option. So the mount + agent run as root (`sudo -E`) so the mount is root-owned
+and the tab can read it. (A user-mounted branch shows up empty in the tab — a good joint
+feature request for E2B/lakeFS; see `PRESENTATION.md`.)
+
+---
+
+## Faster startup: prebaked E2B template (optional)
+
+By default the sandbox does a one-time runtime install of `everest` + `fuse` + python deps.
+A prebaked template removes that. Measured `create + provision` (ready-to-mount), n=3:
+
+| Path | Provision | Ready |
+|---|---|---|
+| Runtime install | ~20.9s | ~21.1s |
+| Template (`mount-receipts`) | ~0.9s | ~2.7s |
+
+Build it once and point `.env` at it:
+
+```bash
+cd template
+cp ../build/bin/everest ./everest      # binary into the build context (gitignored)
+e2b template build --name mount-receipts   # requires `e2b auth login`
+# then set E2B_TEMPLATE=mount-receipts in .env
+```
+
+The template bakes `fuse3` + the everest binary + python deps (installed system-wide so the
+root-run agent can import them); the agent package is uploaded fresh each run, so the template
+never ships stale code. Reproduce the numbers with `scripts/benchmark_provision.py`.
+
+---
+
+## Layout
+
+```
+src/mount_receipts/
+  config.py         env-driven config
+  sample_data.py    synthetic messy inbox generator (multi-format) + expected manifest
+  extraction.py     gpt-4o vision extraction + PDF rasterization/page-stacking (PyMuPDF)
+  validation.py     three-phase rules + ledger completeness (pure; unit-tested)
+  agent_runner.py   the in-sandbox agent: triage / extract / validate over the mount
+  e2b_session.py    sandbox provisioning + everest mount/commit/umount (as root)
+  orchestrator.py   host: branch → reset outputs → sandbox → phases → manifest → gate → merge
+  main.py           CLI entry point (--no-merge, --branch, --keep-sandbox)
+scripts/            setup_lakefs_repo · upload_sample_data · upload_archive · run_demo · benchmark_provision
+lakefs_actions/     validate_ledger.yaml  (pre-merge gate)
+template/           e2b.Dockerfile + e2b.toml  (optional prebaked sandbox)
+tests/              validation unit tests
+PRESENTATION.md     E2B-facing demo guide (story, architecture, measured numbers, demo script)
+```

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/lakefs_actions/validate_ledger.yaml
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/lakefs_actions/validate_ledger.yaml
@@ -1,0 +1,34 @@
+name: Ledger Quality Pre-Merge Gate
+on:
+  pre-merge:
+    branches:
+      - main
+
+hooks:
+  - id: check_ledger_validation
+    type: lua
+    properties:
+      script: |
+        local json = require("encoding/json")
+        local lakefs = require("lakefs")
+
+        -- Read the ledger validation result the agent committed on its branch.
+        local code, body = lakefs.get_object(
+          action.repository_id,
+          action.source_ref,
+          "validation/latest_result.json"
+        )
+
+        if code ~= 200 then
+          error("Pre-merge gate: could not find validation/latest_result.json on branch '"
+            .. action.source_ref .. "'. Run the receipts agent before merging.")
+        end
+
+        local result = json.unmarshal(body)
+
+        if result["status"] ~= "passed" then
+          error("Pre-merge gate FAILED: ledger did not pass validation. "
+            .. "Summary: " .. (result["summary"] or "unknown"))
+        end
+
+        print("Pre-merge gate PASSED: " .. (result["summary"] or "ok"))

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/pyproject.toml
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/pyproject.toml
@@ -1,0 +1,33 @@
+[project]
+name = "mount-receipts"
+version = "0.1.0"
+description = "Agentic receipt/invoice curation into a clean ledger, using lakeFS Mount (everest) inside an E2B sandbox"
+requires-python = ">=3.11"
+dependencies = [
+    "lakefs-e2b-common",
+    "e2b>=1.0.0",
+    "lakefs",
+    "python-dotenv>=1.0.0",
+    "rich>=13.0.0",
+    "openai>=1.0.0",          # vision model: gpt-4o
+    "python-dateutil>=2.8.0", # date sanity checks
+    # File/format helpers for the synthetic receipts + PDF rasterization:
+    "pillow>=10.0.0",
+    "pymupdf>=1.24.0",
+    "pytest>=7.0.0",
+]
+
+[tool.uv.sources]
+lakefs-e2b-common = { workspace = true }
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/mount_receipts"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+addopts = "--import-mode=importlib"

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/scripts/benchmark_provision.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/scripts/benchmark_provision.py
@@ -1,0 +1,71 @@
+"""Benchmark per-run sandbox setup: prebaked template vs runtime install.
+
+The template's whole job is to remove per-run provisioning (apt fuse3 + uploading the
+everest binary + pip deps). This measures exactly that — sandbox create + provision
+(i.e. time until the sandbox is ready to mount) — isolated from the vision/agent work,
+so the numbers are dataset-independent and honest.
+
+    uv run python scripts/benchmark_provision.py --mode template --runs 3
+    uv run python scripts/benchmark_provision.py --mode runtime  --runs 3
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+
+from e2b import Sandbox
+
+from mount_receipts import e2b_session as sess
+from mount_receipts.config import load_config
+
+
+def one_run(cfg, use_template: bool) -> dict:
+    kw = {"api_key": cfg.e2b_api_key, "envs": cfg.sandbox_envs(), "timeout": 900}
+    if use_template:
+        kw["template"] = cfg.e2b_template
+    t0 = time.monotonic()
+    sbx = Sandbox.create(**kw)
+    t1 = time.monotonic()
+    try:
+        sess.provision(sbx, use_template=use_template)
+        t2 = time.monotonic()
+    finally:
+        try:
+            sbx.kill()
+        except Exception:
+            pass
+    return {"create_s": round(t1 - t0, 1), "provision_s": round(t2 - t1, 1), "ready_s": round(t2 - t0, 1)}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=["template", "runtime"], required=True)
+    ap.add_argument("--runs", type=int, default=3)
+    args = ap.parse_args()
+
+    cfg = load_config()
+    use_template = args.mode == "template"
+    if use_template and not cfg.e2b_template:
+        raise SystemExit("E2B_TEMPLATE is not set — can't benchmark the template path.")
+
+    rows = []
+    for i in range(args.runs):
+        r = one_run(cfg, use_template)
+        print(f"  run {i + 1}/{args.runs}: create={r['create_s']}s  provision={r['provision_s']}s  ready={r['ready_s']}s")
+        rows.append(r)
+
+    agg = {
+        k: {
+            "mean": round(statistics.mean(r[k] for r in rows), 1),
+            "min": min(r[k] for r in rows),
+            "max": max(r[k] for r in rows),
+        }
+        for k in ("create_s", "provision_s", "ready_s")
+    }
+    print(json.dumps({"mode": args.mode, "template": cfg.e2b_template or None, "runs": args.runs, "agg": agg}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/scripts/run_demo.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/scripts/run_demo.py
@@ -1,0 +1,22 @@
+"""Convenience wrapper: set up repo + gate, upload the inbox, then run the agent."""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def run(cmd: list[str]) -> None:
+    print(f"\n>>> {' '.join(cmd)}\n")
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+
+def main() -> None:
+    run(["uv", "run", "python", "scripts/setup_lakefs_repo.py"])
+    run(["uv", "run", "python", "scripts/upload_sample_data.py"])
+    run(["uv", "run", "python", "-m", "mount_receipts.main"])
+
+
+if __name__ == "__main__":
+    main()

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/scripts/setup_lakefs_repo.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/scripts/setup_lakefs_repo.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+
 from lakefs_e2b_common.lakefs_client import get_or_create_repo, make_client, upload_lakefsactions_yaml
 from mount_receipts.config import load_config
 

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/scripts/setup_lakefs_repo.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/scripts/setup_lakefs_repo.py
@@ -1,0 +1,26 @@
+"""Create the lakeFS repo (if needed) and install the pre-merge ledger gate on main."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from lakefs_e2b_common.lakefs_client import get_or_create_repo, make_client, upload_lakefsactions_yaml
+from mount_receipts.config import load_config
+
+
+def main() -> None:
+    cfg = load_config()
+    print(f"  Connecting to lakeFS at {cfg.lakefs_endpoint}...")
+    client = make_client(cfg.lakefs_endpoint, cfg.lakefs_access_key_id, cfg.lakefs_secret_access_key)
+
+    print(f"  Ensuring repository '{cfg.lakefs_repository}' exists...")
+    repo = get_or_create_repo(client, cfg.lakefs_repository, cfg.lakefs_storage_namespace)
+    print(f"  Repository '{cfg.lakefs_repository}' is ready.")
+
+    yaml_path = Path(__file__).parent.parent / "lakefs_actions" / "validate_ledger.yaml"
+    print("  Uploading _lakefs_actions/validate_ledger.yaml to main...")
+    upload_lakefsactions_yaml(repo, yaml_path.read_text(encoding="utf-8"), filename="validate_ledger.yaml")
+    print("  Pre-merge gate installed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/scripts/upload_archive.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/scripts/upload_archive.py
@@ -1,0 +1,52 @@
+"""Upload a large, never-opened ``archive/`` to lakeFS to showcase Mount's lazy fetch.
+
+The agent only ever globs ``inbox/``, so nothing under ``archive/`` is read. When the
+branch is mounted, everest fetches file *bytes* lazily — so a multi-GB archive can be
+mounted instantly and never downloaded. This makes the "bring over a massive dataset,
+use only a sliver" story concrete.
+
+Bulk upload goes through ``lakectl fs upload -r`` (streams via presigned URLs), which is
+far more efficient than the SDK for many/large files.
+
+Size is tunable (it's a one-time, bandwidth-bound upload):
+    ARCHIVE_FILES (default 1000) × ARCHIVE_SIZE_KB (default 256)  ≈ 250 MB by default
+    e.g.  ARCHIVE_FILES=4000 ARCHIVE_SIZE_KB=512  uv run python scripts/upload_archive.py   # ~2 GB
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+
+from mount_receipts.config import load_config
+
+
+def main() -> None:
+    cfg = load_config()
+    n_files = int(os.environ.get("ARCHIVE_FILES", "1000"))
+    size_kb = int(os.environ.get("ARCHIVE_SIZE_KB", "256"))
+    total_mb = n_files * size_kb / 1024
+    env = {**os.environ, **cfg.lakectl_envs()}
+    uri = f"lakefs://{cfg.lakefs_repository}/{cfg.lakefs_branch}/archive/"
+
+    print(f"  Generating {n_files} decoy files × {size_kb} KB (~{total_mb:.0f} MB)...")
+    with tempfile.TemporaryDirectory() as tmp:
+        nbytes = size_kb * 1024
+        for i in range(n_files):
+            # unique content per file (avoids content-addressed dedup hiding the size)
+            with open(os.path.join(tmp, f"blob_{i:06d}.bin"), "wb") as f:
+                f.write(f"decoy {i}\n".encode() + os.urandom(nbytes))
+        print(f"  Uploading to {uri} via lakectl (presigned, direct to object store)...")
+        subprocess.run(["lakectl", "fs", "upload", "-r", "-s", tmp, uri], env=env, check=True)
+
+    print("  Committing...")
+    subprocess.run(
+        ["lakectl", "commit", f"lakefs://{cfg.lakefs_repository}/{cfg.lakefs_branch}",
+         "-m", f"Add archive/: {n_files} files (~{total_mb:.0f} MB), never opened by the agent"],
+        env=env, check=True,
+    )
+    print(f"  Done. archive/ now holds {n_files} files (~{total_mb:.0f} MB) the agent never reads.")
+
+
+if __name__ == "__main__":
+    main()

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/scripts/upload_sample_data.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/scripts/upload_sample_data.py
@@ -1,0 +1,45 @@
+"""Generate the messy receipt inbox and upload it to lakeFS main under inbox/."""
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from lakefs_e2b_common.lakefs_client import commit, get_or_create_repo, make_client, write_object
+from mount_receipts.config import load_config
+from mount_receipts.sample_data import generate
+
+ORACLE = "_expected_manifest.json"
+
+
+def main() -> None:
+    cfg = load_config()
+    client = make_client(cfg.lakefs_endpoint, cfg.lakefs_access_key_id, cfg.lakefs_secret_access_key)
+    repo = get_or_create_repo(client, cfg.lakefs_repository, cfg.lakefs_storage_namespace)
+    branch = repo.branch(cfg.lakefs_branch)
+
+    # Clear any existing inbox so re-uploads are clean (no stale files from older formats).
+    stale = [o.path for o in branch.objects(prefix="inbox/", max_amount=100000)]
+    if stale:
+        branch.delete_objects(stale)
+        print(f"  Cleared {len(stale)} existing inbox object(s).")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        summary = generate(tmp)
+        n = 0
+        for p in sorted(Path(tmp).iterdir()):
+            if p.name == ORACLE:
+                continue  # keep the oracle out of the agent's inbox
+            write_object(branch, f"inbox/{p.name}", p.read_bytes())
+            n += 1
+        # store the oracle at the repo root for the demo author (agent never reads it)
+        write_object(branch, "expected_manifest.json", json.dumps(summary, indent=2))
+
+    print(f"  Uploaded {n} receipt files to inbox/ on '{cfg.lakefs_branch}'.")
+    commit_id = commit(branch, "Upload messy receipt inbox", {"source": "upload_sample_data"})
+    print(f"  Committed: {commit_id[:12]}")
+    print(f"  Expected outcome: {summary['accept']} accepted, {summary['reject']} rejected, {summary['drop']} dropped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/scripts/upload_sample_data.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/scripts/upload_sample_data.py
@@ -5,6 +5,10 @@ import json
 import tempfile
 from pathlib import Path
 
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+
 from lakefs_e2b_common.lakefs_client import commit, get_or_create_repo, make_client, write_object
 from mount_receipts.config import load_config
 from mount_receipts.sample_data import generate

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/__init__.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/__init__.py
@@ -1,0 +1,7 @@
+"""Use case 3 — Receipts → Clean Ledger via lakeFS Mount.
+
+Scaffold only. The implementation (E2B template with the everest binary,
+write-mode mount lifecycle, multimodal extraction, three-phase validation,
+and the pre-merge gate) is built once lakeFS Cloud credentials are available.
+See README.md in this directory for the design.
+"""

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/agent_runner.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/agent_runner.py
@@ -1,0 +1,211 @@
+"""The agent, as it runs *inside* the E2B sandbox over the mounted lakeFS branch.
+
+It is invoked once per phase by the host orchestrator (which does an ``everest commit``
+after each phase, producing a progressive commit history on the branch):
+
+    python -m mount_receipts.agent_runner triage   /mnt/repo
+    python -m mount_receipts.agent_runner extract   /mnt/repo
+    python -m mount_receipts.agent_runner validate  /mnt/repo
+
+Everything is ordinary filesystem I/O against ``<root>`` — the agent has no idea it
+is talking to lakeFS. State is passed between phases through files on the mount:
+
+    inbox/<receipt files>            (input)
+    sidecars/<file>.json             (per-file extraction + outcome, written in triage)
+    triage.json                      (kept / dropped lists)
+    ledger_draft.json                (rows that reached business-rule validation)
+    ledger.csv                       (final accepted rows)
+    rejects.csv                      (dropped + rejected rows, with reasons)
+    validation/latest_result.json    (read by the lakeFS pre-merge gate)
+"""
+from __future__ import annotations
+
+import csv
+import glob
+import json
+import os
+import sys
+from datetime import date
+
+from mount_receipts.extraction import (
+    extract,
+    load_image_png,
+    missing_required,
+    sha256_file,
+)
+from mount_receipts.validation import (
+    POLICY_CAP_USD,
+    FileOutcome,
+    check_business_rules,
+    validate_ledger,
+)
+
+INBOX = "inbox"
+SIDECARS = "sidecars"
+
+
+def _p(root: str, *parts: str) -> str:
+    return os.path.join(root, *parts)
+
+
+def _write_json(path: str, obj) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(obj, f, indent=2)
+
+
+def _read_json(path: str):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _inbox_files(root: str) -> list[str]:
+    files = [
+        os.path.basename(p)
+        for p in glob.glob(_p(root, INBOX, "*"))
+        if os.path.isfile(p)
+    ]
+    return sorted(files)
+
+
+# --- Phase 1: triage -------------------------------------------------------
+
+def phase_triage(root: str, model: str) -> dict:
+    inbox = _inbox_files(root)
+    os.makedirs(_p(root, SIDECARS), exist_ok=True)
+    seen_hashes: dict[str, str] = {}
+    kept: list[str] = []
+    dropped: list[dict] = []
+
+    for fn in inbox:
+        path = _p(root, INBOX, fn)
+        digest = sha256_file(path)
+        if digest in seen_hashes:
+            dropped.append({"file": fn, "phase": 1, "reason": f"exact duplicate of {seen_hashes[digest]}"})
+            continue
+        seen_hashes[digest] = fn
+
+        png = load_image_png(path)
+        if png is None:
+            dropped.append({"file": fn, "phase": 1, "reason": "corrupt / unreadable file"})
+            continue
+
+        record = extract(png, model=model)
+        _write_json(_p(root, SIDECARS, fn + ".json"), record)
+        if not record.get("is_receipt"):
+            dropped.append({"file": fn, "phase": 1, "reason": "not a receipt"})
+            continue
+        kept.append(fn)
+
+    _write_json(_p(root, "triage.json"), {"inbox": inbox, "kept": kept, "dropped": dropped})
+    summary = {"phase": "triage", "inbox": len(inbox), "kept": len(kept), "dropped": len(dropped)}
+    print(json.dumps(summary))
+    return summary
+
+
+# --- Phase 2: extract ------------------------------------------------------
+
+def phase_extract(root: str) -> dict:
+    triage = _read_json(_p(root, "triage.json"))
+    draft: list[dict] = []
+    failed: list[dict] = []
+
+    for fn in triage["kept"]:
+        record = _read_json(_p(root, SIDECARS, fn + ".json"))
+        miss = missing_required(record)
+        if miss:
+            failed.append({"file": fn, "phase": 2, "reason": f"missing fields: {', '.join(miss)}"})
+        else:
+            draft.append({"source_file": fn, "record": record})
+
+    _write_json(_p(root, "ledger_draft.json"), {"rows": draft, "extraction_failed": failed})
+    summary = {"phase": "extract", "kept": len(triage["kept"]), "extracted": len(draft), "extraction_failed": len(failed)}
+    print(json.dumps(summary))
+    return summary
+
+
+# --- Phase 3: validate -----------------------------------------------------
+
+def _today() -> date:
+    override = os.environ.get("DEMO_TODAY", "").strip()
+    return date.fromisoformat(override) if override else date.today()
+
+
+def phase_validate(root: str) -> dict:
+    triage = _read_json(_p(root, "triage.json"))
+    draft_doc = _read_json(_p(root, "ledger_draft.json"))
+    draft = sorted(draft_doc["rows"], key=lambda r: r["source_file"])
+    today = _today()
+
+    # Duplicate invoice numbers are ambiguous → every row sharing one is rejected.
+    inv_counts: dict[str, int] = {}
+    for row in draft:
+        inv = (row["record"].get("invoice_no") or "").strip()
+        if inv:
+            inv_counts[inv] = inv_counts.get(inv, 0) + 1
+
+    outcomes: list[FileOutcome] = []
+    # phase-1 drops
+    for d in triage["dropped"]:
+        outcomes.append(FileOutcome(d["file"], "dropped", d.get("phase", 1), d["reason"]))
+    # phase-2 extraction failures → rejected
+    for d in draft_doc.get("extraction_failed", []):
+        outcomes.append(FileOutcome(d["file"], "rejected", 2, d["reason"]))
+
+    # phase-3 business rules
+    for row in draft:
+        rec = row["record"]
+        reasons = check_business_rules(rec, today=today, seen_invoice_nos=set(), policy_cap=POLICY_CAP_USD)
+        inv = (rec.get("invoice_no") or "").strip()
+        if inv and inv_counts.get(inv, 0) > 1:
+            reasons.append(f"duplicate invoice number ({inv})")
+        if reasons:
+            outcomes.append(FileOutcome(row["source_file"], "rejected", 3, "; ".join(reasons), rec))
+        else:
+            outcomes.append(FileOutcome(row["source_file"], "accepted", 3, "", rec))
+
+    result = validate_ledger(triage["inbox"], outcomes)
+
+    # human-facing ledger + rejects
+    with open(_p(root, "ledger.csv"), "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["source_file", "vendor", "invoice_no", "date", "currency", "total", "num_items"])
+        for o in result.accepted:
+            r = o.record or {}
+            w.writerow([o.source_file, r.get("vendor", ""), r.get("invoice_no", ""), r.get("date", ""),
+                        r.get("currency", ""), r.get("total", ""), len(r.get("line_items") or [])])
+    with open(_p(root, "rejects.csv"), "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["source_file", "outcome", "phase", "reason"])
+        for o in outcomes:
+            if o.outcome != "accepted":
+                w.writerow([o.source_file, o.outcome, o.phase, o.reason])
+
+    _write_json(_p(root, "validation", "latest_result.json"), result.to_dict())
+    summary = result.to_dict()
+    summary["phase"] = "validate"
+    print(json.dumps({k: summary[k] for k in ("phase", "status", "summary", "accepted", "rejected", "dropped")}))
+    return summary
+
+
+PHASES = {"triage": 1, "extract": 2, "validate": 3}
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3 or argv[1] not in PHASES:
+        print(f"usage: agent_runner <{'|'.join(PHASES)}> <mount_dir>", file=sys.stderr)
+        return 2
+    phase, root = argv[1], argv[2]
+    model = os.environ.get("OPENAI_MODEL", "gpt-4o")
+    if phase == "triage":
+        phase_triage(root, model)
+    elif phase == "extract":
+        phase_extract(root)
+    else:
+        result = phase_validate(root)
+        return 0 if result["status"] == "passed" else 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/config.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/config.py
@@ -1,0 +1,60 @@
+"""Configuration for the Mount Receipts demo, loaded from the environment."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lakefs_e2b_common.env import optional, require
+
+
+@dataclass
+class Config:
+    # lakeFS (Cloud / Enterprise — Mount requires Enterprise)
+    lakefs_endpoint: str
+    lakefs_access_key_id: str
+    lakefs_secret_access_key: str
+    lakefs_repository: str
+    lakefs_storage_namespace: str
+    lakefs_branch: str
+    # E2B
+    e2b_api_key: str
+    e2b_team: str
+    e2b_template: str          # optional prebaked template name; "" = default + runtime install
+    # OpenAI vision
+    openai_api_key: str
+    openai_model: str
+    # demo controls
+    demo_today: str            # pin "today" for reproducible date checks; "" = real today
+
+    def lakectl_envs(self) -> dict[str, str]:
+        """Env vars everest/lakectl read inside the sandbox (creds never passed as CLI flags)."""
+        return {
+            "LAKECTL_SERVER_ENDPOINT_URL": self.lakefs_endpoint,
+            "LAKECTL_CREDENTIALS_ACCESS_KEY_ID": self.lakefs_access_key_id,
+            "LAKECTL_CREDENTIALS_SECRET_ACCESS_KEY": self.lakefs_secret_access_key,
+        }
+
+    def sandbox_envs(self) -> dict[str, str]:
+        """Full env passed to the sandbox: lakeFS creds + OpenAI + demo controls."""
+        envs = self.lakectl_envs()
+        envs["OPENAI_API_KEY"] = self.openai_api_key
+        envs["OPENAI_MODEL"] = self.openai_model
+        if self.demo_today:
+            envs["DEMO_TODAY"] = self.demo_today
+        return envs
+
+
+def load_config() -> Config:
+    return Config(
+        lakefs_endpoint=require("LAKEFS_ENDPOINT"),
+        lakefs_access_key_id=require("LAKEFS_ACCESS_KEY_ID"),
+        lakefs_secret_access_key=require("LAKEFS_SECRET_ACCESS_KEY"),
+        lakefs_repository=require("LAKEFS_REPOSITORY"),
+        lakefs_storage_namespace=optional("LAKEFS_STORAGE_NAMESPACE"),
+        lakefs_branch=optional("LAKEFS_BRANCH", "main"),
+        e2b_api_key=require("E2B_API_KEY"),
+        e2b_team=optional("E2B_TEAM"),
+        e2b_template=optional("E2B_TEMPLATE"),
+        openai_api_key=require("OPENAI_API_KEY"),
+        openai_model=optional("OPENAI_MODEL", "gpt-4o"),
+        demo_today=optional("DEMO_TODAY"),
+    )

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/e2b_session.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/e2b_session.py
@@ -1,0 +1,126 @@
+"""E2B sandbox lifecycle for lakeFS Mount: provision → mount → run → commit → umount.
+
+The agent's work happens *inside* the sandbox on the mounted branch, so this module
+runs everything via ``sandbox.commands.run`` over an ``everest`` FUSE mount. Credentials
+reach the sandbox only as env vars (set at ``Sandbox.create``), never as CLI flags.
+
+When a prebaked template is used (``cfg.e2b_template``), ``provision`` skips the apt/pip/
+binary installs — the template already contains everest, fuse, the deps, and the package.
+"""
+from __future__ import annotations
+
+import pathlib
+from dataclasses import dataclass
+
+_HERE = pathlib.Path(__file__).resolve()
+PKG_DIR = _HERE.parent                                   # src/mount_receipts
+USECASE_DIR = _HERE.parents[2]                           # usecases/03-mount-receipts
+EVEREST_BIN = USECASE_DIR / "build" / "bin" / "everest"  # gitignored Linux binary
+
+# Only the modules the in-sandbox agent needs (agent_runner + its imports).
+SANDBOX_MODULES = ["__init__.py", "validation.py", "extraction.py", "agent_runner.py"]
+
+MOUNT_DIR = "/home/user/mnt"
+SANDBOX_PKG_ROOT = "/home/user"                          # so `python -m mount_receipts...` resolves
+PIP_DEPS = "openai pillow pymupdf python-dateutil"
+
+
+@dataclass
+class CmdResult:
+    cmd: str
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+try:  # the e2b SDK raises this on any non-zero command exit
+    from e2b.sandbox.commands.command_handle import CommandExitException
+except Exception:  # pragma: no cover - import-path safety across SDK versions
+    CommandExitException = None
+
+
+def run(sbx, cmd: str, *, timeout: int = 300, check: bool = True) -> CmdResult:
+    """Run a command. ``sbx.commands.run`` raises on non-zero exit, so catch that and
+    surface a CmdResult; only re-raise (as RuntimeError) when ``check`` is set."""
+    try:
+        r = sbx.commands.run(cmd, timeout=timeout)
+        res = CmdResult(cmd, r.exit_code, r.stdout or "", r.stderr or "")
+    except Exception as exc:  # CommandExitException (non-zero exit) or transport error
+        if CommandExitException is not None and isinstance(exc, CommandExitException):
+            res = CmdResult(cmd, getattr(exc, "exit_code", 1), getattr(exc, "stdout", "") or "",
+                            getattr(exc, "stderr", "") or str(exc))
+        else:
+            raise
+    if check and res.exit_code != 0:
+        raise RuntimeError(f"command failed (exit {res.exit_code}): {cmd}\n{res.stderr[-1500:]}")
+    return res
+
+
+def provision(sbx, *, use_template: bool) -> None:
+    """Prepare the sandbox to mount and run the agent.
+
+    The slow, stable pieces (FUSE, the everest binary, python deps) are installed at
+    runtime only when no prebaked template provides them. The agent package itself is
+    *always* uploaded fresh from the repo, so a baked template can never ship stale
+    agent code.
+    """
+    if not use_template:
+        if not EVEREST_BIN.exists():
+            raise FileNotFoundError(
+                f"everest binary not found at {EVEREST_BIN}. Download the Linux x86_64 build and "
+                "extract it there (see README)."
+            )
+        # FUSE userspace (baked into the template otherwise)
+        run(sbx, "sudo apt-get update -qq && sudo apt-get install -y -qq fuse3", timeout=300)
+        run(sbx, "echo user_allow_other | sudo tee -a /etc/fuse.conf >/dev/null", check=False)
+        # everest binary
+        sbx.files.write("/home/user/everest", EVEREST_BIN.read_bytes())
+        run(sbx, "sudo mv /home/user/everest /usr/local/bin/everest && sudo chmod +x /usr/local/bin/everest && everest --version")
+        # python deps for the agent — system-wide (sudo) so root can import them
+        run(sbx, f"sudo pip install -q {PIP_DEPS}", timeout=420)
+
+    # /dev/fuse is a per-sandbox device, not part of the image — relax its perms every
+    # run so a non-root mount works (template or runtime-install path alike).
+    run(sbx, "sudo chmod 666 /dev/fuse", check=False)
+
+    # agent package modules — always uploaded fresh
+    run(sbx, f"mkdir -p {SANDBOX_PKG_ROOT}/mount_receipts")
+    for mod in SANDBOX_MODULES:
+        sbx.files.write(f"{SANDBOX_PKG_ROOT}/mount_receipts/{mod}", (PKG_DIR / mod).read_text(encoding="utf-8"))
+
+
+# Everything that touches the mount runs as root (sudo -E): the FUSE mount must be
+# root-owned so E2B's root-owned envd (which serves the dashboard Filesystem tab) can see
+# it; a user-owned everest mount is invisible to root, and everest has no allow_other.
+def mount(sbx, repo: str, branch: str, *, mount_dir: str = MOUNT_DIR) -> None:
+    run(sbx, f"sudo mkdir -p {mount_dir}")
+    run(
+        sbx,
+        f"sudo -E everest mount lakefs://{repo}/{branch}/ {mount_dir} --protocol fuse --write-mode",
+        timeout=180,
+    )
+
+
+def run_phase(sbx, phase: str, *, mount_dir: str = MOUNT_DIR) -> CmdResult:
+    return run(
+        sbx,
+        f"sudo -E env PYTHONPATH={SANDBOX_PKG_ROOT} python -m mount_receipts.agent_runner {phase} {mount_dir}",
+        timeout=420,
+        check=False,  # validate phase returns exit 1 on a failed ledger; caller inspects result file
+    )
+
+
+def commit(sbx, msg: str, *, mount_dir: str = MOUNT_DIR) -> CmdResult:
+    """Commit mounted changes. A phase that produced no diff is a no-op, not an error."""
+    r = run(sbx, f'sudo -E everest commit {mount_dir} -m "{msg}"', timeout=180, check=False)
+    if r.exit_code != 0 and "no changes" not in (r.stdout + r.stderr).lower():
+        raise RuntimeError(f"everest commit failed: {r.stderr[-1500:]}")
+    return r
+
+
+def read_mount_file(sbx, rel_path: str, *, mount_dir: str = MOUNT_DIR) -> str:
+    return run(sbx, f"sudo cat {mount_dir}/{rel_path}").stdout
+
+
+def umount(sbx, *, mount_dir: str = MOUNT_DIR) -> None:
+    run(sbx, f"sudo -E everest umount {mount_dir}", check=False)

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/extraction.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/extraction.py
@@ -1,0 +1,143 @@
+"""Multimodal extraction: read a receipt image/PDF and pull out structured fields.
+
+A single vision call per file does double duty:
+  - **classification** (``is_receipt``) — used by Phase-1 triage to drop non-receipts
+  - **extraction** (vendor, date, invoice no, currency, line items, total)
+
+Images are read with ordinary file I/O (the files live on the mounted lakeFS branch),
+re-encoded to PNG to validate readability, and PDFs are rasterized with PyMuPDF.
+A file that cannot be decoded returns ``None`` from :func:`load_image_png`, which
+Phase-1 treats as a corrupt-file drop — no model call needed.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import json
+import os
+
+EXTRACTION_SYSTEM_PROMPT = (
+    "You are a precise receipt and invoice data extractor. You are shown one image. "
+    "Return ONLY a JSON object with exactly these keys:\n"
+    '  "is_receipt": boolean — true only if the image is a purchase receipt or invoice,\n'
+    '  "vendor": string — merchant/business name, or "" if unknown,\n'
+    '  "date": string — the transaction date exactly as printed (any format), or "",\n'
+    '  "invoice_no": string — invoice/receipt number, or "",\n'
+    '  "currency": string — ISO 4217 code (e.g. USD, EUR), or "",\n'
+    '  "line_items": array of objects {"name": string, "amount": number},\n'
+    '  "total": number or null — the grand total.\n'
+    "Use numeric values (not strings) for amounts and total. If the image is not a "
+    "receipt/invoice (e.g. a photo), set is_receipt=false and leave the other fields empty/null. "
+    "Do not guess values that are not visible."
+)
+
+REQUIRED_FIELDS = ("vendor", "date", "currency", "total")
+
+
+def sha256_file(path: str) -> str:
+    """Content hash of a file, for exact-duplicate detection."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_image_png(path: str) -> bytes | None:
+    """Return PNG bytes for an image or the first page of a PDF; ``None`` if undecodable."""
+    ext = os.path.splitext(path)[1].lower()
+    try:
+        if ext == ".pdf":
+            import fitz  # PyMuPDF
+            from PIL import Image
+
+            doc = fitz.open(path)
+            if doc.page_count == 0:
+                return None
+            pages = []
+            for i in range(doc.page_count):
+                pix = doc.load_page(i).get_pixmap(dpi=150)
+                pages.append(Image.open(io.BytesIO(pix.tobytes("png"))).convert("RGB"))
+            if len(pages) == 1:
+                out = pages[0]
+            else:  # stack pages vertically so a total on a later page is still read
+                w = max(p.width for p in pages)
+                out = Image.new("RGB", (w, sum(p.height for p in pages)), (255, 255, 255))
+                y = 0
+                for p in pages:
+                    out.paste(p, (0, y))
+                    y += p.height
+            buf = io.BytesIO()
+            out.save(buf, "PNG")
+            return buf.getvalue()
+        else:
+            from PIL import Image
+
+            # PIL natively decodes jpeg/png/webp/tiff/bmp/gif; unsupported files (txt,
+            # zip, …) raise and become a triage "corrupt / unreadable" drop.
+            with Image.open(path) as im:
+                im.load()
+                buf = io.BytesIO()
+                im.convert("RGB").save(buf, "PNG")
+                return buf.getvalue()
+    except Exception:
+        return None
+
+
+def _coerce(raw: dict) -> dict:
+    """Normalise a model response into the canonical record shape."""
+    items = []
+    for it in raw.get("line_items") or []:
+        if isinstance(it, dict):
+            items.append({"name": str(it.get("name", "")).strip(), "amount": it.get("amount")})
+    return {
+        "is_receipt": bool(raw.get("is_receipt", False)),
+        "vendor": (raw.get("vendor") or "").strip(),
+        "date": (raw.get("date") or "").strip(),
+        "invoice_no": (raw.get("invoice_no") or "").strip(),
+        "currency": (raw.get("currency") or "").strip().upper(),
+        "line_items": items,
+        "total": raw.get("total"),
+    }
+
+
+def missing_required(record: dict) -> list[str]:
+    """Required fields that are empty/None (Phase-2 extraction completeness)."""
+    miss = []
+    for f in REQUIRED_FIELDS:
+        v = record.get(f)
+        if v is None or (isinstance(v, str) and not v.strip()):
+            miss.append(f)
+    return miss
+
+
+def extract(png_bytes: bytes, *, model: str, client=None, api_key: str | None = None) -> dict:
+    """Run the vision model on PNG bytes and return a canonical record dict."""
+    if client is None:
+        from openai import OpenAI
+
+        client = OpenAI(api_key=api_key or os.environ.get("OPENAI_API_KEY"))
+
+    b64 = base64.b64encode(png_bytes).decode("ascii")
+    resp = client.chat.completions.create(
+        model=model,
+        temperature=0,
+        response_format={"type": "json_object"},
+        messages=[
+            {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Extract the receipt fields as JSON."},
+                    {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}},
+                ],
+            },
+        ],
+    )
+    content = resp.choices[0].message.content or "{}"
+    try:
+        raw = json.loads(content)
+    except json.JSONDecodeError:
+        raw = {}
+    return _coerce(raw)

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/main.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/main.py
@@ -5,6 +5,11 @@ import argparse
 import json
 import os
 from datetime import datetime
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent.parent.parent.parent / ".env")
 
 from mount_receipts.config import load_config
 from mount_receipts.orchestrator import print_report, run

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/main.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/main.py
@@ -1,0 +1,48 @@
+"""Entry point: run the receipts → ledger agent over a lakeFS Mount in E2B."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+
+from mount_receipts.config import load_config
+from mount_receipts.orchestrator import print_report, run
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Receipts → Clean Ledger: an agent curating files on a lakeFS Mount in E2B"
+    )
+    parser.add_argument("--no-merge", action="store_true", help="Do not merge into main even if validation passes")
+    parser.add_argument("--branch", default=None, help="Source branch to start from (default LAKEFS_BRANCH or 'main')")
+    parser.add_argument("--keep-sandbox", action="store_true", help="Do not kill the sandbox at the end (for debugging)")
+    args = parser.parse_args()
+
+    cfg = load_config()
+    result = run(cfg, source_branch=args.branch, do_merge=not args.no_merge, keep_sandbox=args.keep_sandbox)
+    print_report(cfg, result)
+
+    ts = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    os.makedirs("outputs", exist_ok=True)
+    out = f"outputs/report-{ts}.json"
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "branch_name": result.branch_name,
+                "sandbox_id": result.sandbox_id,
+                "sandbox_url": result.sandbox_url,
+                "passed": result.passed,
+                "merged": result.merged,
+                "phases": result.phases,
+                "validation": result.validation,
+            },
+            f,
+            indent=2,
+        )
+    print(f"  Report saved to {out}")
+    return 0 if result.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/orchestrator.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/orchestrator.py
@@ -1,0 +1,185 @@
+"""Host orchestration: branch → sandbox → mount → phased agent → commit → gate → merge.
+
+The host owns lakeFS branch creation and the final merge; the agent (inside the sandbox)
+owns the work on the mounted filesystem. Each phase is committed with ``everest commit``,
+so the branch ends up with a progressive, auditable commit per phase.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from e2b import Sandbox
+
+from lakefs_e2b_common.lakefs_client import (
+    commit,
+    create_branch,
+    get_or_create_repo,
+    make_client,
+    merge_branch,
+    write_object,
+)
+from mount_receipts import e2b_session as sess
+from mount_receipts.config import Config
+
+PHASES = [
+    ("triage", "Triage (structural)"),
+    ("extract", "Extract (multimodal)"),
+    ("validate", "Validate (business rules)"),
+]
+
+# Agent output artefacts. A merging run promotes these to `main`, so a re-run would
+# otherwise branch from a "polluted" main and the phases would no-op. We clear them on
+# the fresh agent branch first, so every run starts from a clean inbox and produces real
+# per-phase commits. (The branch descends from main, so the later merge stays conflict-free.)
+OUTPUT_FILES = ["ledger.csv", "rejects.csv", "ledger_draft.json", "triage.json", "run_manifest.json"]
+OUTPUT_PREFIXES = ["sidecars/", "validation/"]
+
+
+def _reset_branch_outputs(repo, branch_name: str) -> int:
+    """Delete prior agent outputs from the branch so the run starts inbox-only."""
+    b = repo.branch(branch_name)
+    to_delete = [f for f in OUTPUT_FILES if b.object(f).exists()]
+    for prefix in OUTPUT_PREFIXES:
+        to_delete.extend(o.path for o in b.objects(prefix=prefix, max_amount=100000))
+    if to_delete:
+        b.delete_objects(to_delete)
+        commit(b, "Prepare clean run: clear prior agent outputs", {"reset": "true"})
+    return len(to_delete)
+
+
+@dataclass
+class RunResult:
+    branch_name: str
+    sandbox_id: str
+    sandbox_url: str
+    passed: bool
+    merged: bool
+    phases: list[dict] = field(default_factory=list)
+    validation: dict | None = None
+
+
+def _divider() -> None:
+    print("─" * 60)
+
+
+def run(cfg: Config, *, source_branch: str | None = None, do_merge: bool = True, keep_sandbox: bool = False) -> RunResult:
+    source = source_branch or cfg.lakefs_branch
+    client = make_client(cfg.lakefs_endpoint, cfg.lakefs_access_key_id, cfg.lakefs_secret_access_key)
+    repo = get_or_create_repo(client, cfg.lakefs_repository, cfg.lakefs_storage_namespace)
+
+    ts = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    branch_name = f"agent-run-{ts}"
+    print(f"  Creating branch '{branch_name}' from '{source}'...")
+    create_branch(repo, branch_name, source)
+    cleared = _reset_branch_outputs(repo, branch_name)
+    if cleared:
+        print(f"  Cleared {cleared} prior output object(s) — starting from a clean inbox.")
+
+    use_template = bool(cfg.e2b_template)
+    create_kwargs = {"api_key": cfg.e2b_api_key, "envs": cfg.sandbox_envs(), "timeout": 900}
+    if use_template:
+        create_kwargs["template"] = cfg.e2b_template
+    sbx = Sandbox.create(**create_kwargs)
+    print(f"  Sandbox: {sbx.sandbox_id}  (template={cfg.e2b_template or 'default+runtime-install'})")
+
+    phase_summaries: list[dict] = []
+    validation: dict | None = None
+    try:
+        print("  Provisioning sandbox (everest + fuse + agent)..." if not use_template else "  Using prebaked template...")
+        sess.provision(sbx, use_template=use_template)
+        print(f"  Mounting lakefs://{cfg.lakefs_repository}/{branch_name} (FUSE, write-mode)...")
+        sess.mount(sbx, cfg.lakefs_repository, branch_name)
+
+        for i, (phase, name) in enumerate(PHASES, 1):
+            _divider()
+            print(f"  Phase {i} — {name}")
+            _divider()
+            r = sess.run_phase(sbx, phase)
+            summary_line = (r.stdout or r.stderr).strip().splitlines()[-1] if (r.stdout or r.stderr).strip() else ""
+            print(f"    {summary_line}")
+            commit_res = sess.commit(sbx, f"Phase {i} — {name}")
+            commit_id = ""
+            for ln in commit_res.stdout.splitlines():
+                if ln.strip().startswith("ID:"):
+                    commit_id = ln.split("ID:", 1)[1].strip()
+                    break
+            print(f"    committed: {commit_id[:12] or '(no changes)'}")
+            phase_summaries.append({"phase": phase, "name": name, "summary": summary_line, "commit_id": commit_id})
+
+        result_json = sess.read_mount_file(sbx, "validation/latest_result.json")
+        validation = json.loads(result_json)
+        # Keep the mount live when keeping the sandbox, so it can be browsed (e.g. the
+        # E2B dashboard Filesystem tab shows /home/user/mnt as the live lakeFS branch).
+        if not keep_sandbox:
+            sess.umount(sbx)
+    finally:
+        if not keep_sandbox:
+            try:
+                sbx.kill()
+            except Exception:
+                pass
+
+    # Tie the lakeFS branch to the exact E2B sandbox that produced it. `everest commit`
+    # can't set lakeFS commit metadata, so the host adds a manifest commit via the SDK
+    # carrying a clickable "E2B Sandbox" link (the ::lakefs::<name>::url[url:ui] convention)
+    # — restoring the E2B↔lakeFS link the SDK-based use cases show in their commits.
+    sandbox_url = f"https://e2b.dev/dashboard/{cfg.e2b_team}/sandboxes/{sbx.sandbox_id}/monitoring" if cfg.e2b_team else ""
+    try:
+        b = repo.branch(branch_name)
+        write_object(b, "run_manifest.json", json.dumps({
+            "sandbox_id": sbx.sandbox_id,
+            "sandbox_url": sandbox_url,
+            "model": cfg.openai_model,
+            "phases": phase_summaries,
+            "validation": validation,
+        }, indent=2))
+        meta = {
+            "model": cfg.openai_model,
+            "sandbox_id": sbx.sandbox_id,
+            "validation_status": (validation or {}).get("status", "unknown"),
+        }
+        if sandbox_url:
+            meta["::lakefs::E2B Sandbox::url[url:ui]"] = sandbox_url
+        commit(b, "Agent run manifest — E2B sandbox link", meta)
+        print(f"  Run manifest committed (E2B sandbox: {sandbox_url or 'n/a — set E2B_TEAM'})")
+    except Exception as exc:
+        print(f"  (could not write run manifest: {exc})")
+
+    passed = bool(validation and validation.get("status") == "passed")
+    merged = False
+    if passed and do_merge:
+        print(f"\n  Merging '{branch_name}' into '{source}'...")
+        merge_ref = merge_branch(repo.branch(branch_name), repo.branch(source))
+        merged = True
+        print(f"  Merged. ref: {merge_ref}")
+    elif not passed:
+        print(f"\n  Validation did not pass — '{branch_name}' left un-merged for inspection.")
+
+    return RunResult(
+        branch_name=branch_name,
+        sandbox_id=sbx.sandbox_id,
+        sandbox_url=sandbox_url,
+        passed=passed,
+        merged=merged,
+        phases=phase_summaries,
+        validation=validation,
+    )
+
+
+def print_report(cfg: Config, result: RunResult) -> None:
+    _divider()
+    print("  Final Report")
+    _divider()
+    print(f"  Branch   : {result.branch_name}")
+    print(f"  Sandbox  : {result.sandbox_id}")
+    if result.sandbox_url:
+        print(f"  E2B link : {result.sandbox_url}")
+    print(f"  Outcome  : {'PASSED' if result.passed else 'FAILED'}   merged={result.merged}")
+    if result.validation:
+        v = result.validation
+        print(f"  Ledger   : {v.get('accepted')} accepted, {v.get('rejected')} rejected, {v.get('dropped')} dropped")
+        print(f"  Summary  : {v.get('summary')}")
+    print(f"  lakeFS UI: {cfg.lakefs_endpoint}/repositories/{cfg.lakefs_repository}/objects?ref={result.branch_name}")
+    _divider()

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/sample_data.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/sample_data.py
@@ -1,0 +1,202 @@
+"""Generate a messy synthetic ``inbox/`` of receipts & invoices for the demo.
+
+The output is intentionally dirty so each of the three agent phases has something
+to catch:
+
+- Phase 1 (Triage)   : a corrupt file, an exact duplicate, and a non-receipt image
+- Phase 2 (Extract)  : a low-contrast / rotated receipt that still must be read
+- Phase 3 (Validate) : math mismatch, future date, non-USD currency, duplicate
+                       invoice number, and an over-policy-cap total
+
+Receipts are rendered as images (PNG/JPG) and a couple as PDF using Pillow only
+(no extra dependencies). The data is fully deterministic so the demo is reproducible.
+
+Run directly to write the inbox to a local directory:
+    uv run python -m mount_receipts.sample_data ./sample_inbox
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+
+from PIL import Image, ImageDraw, ImageFont
+
+# Business-rule constant the agent's Phase 3 enforces (kept in sync with validation).
+POLICY_CAP_USD = 500.00
+
+
+@dataclass
+class Receipt:
+    filename: str
+    vendor: str
+    date: str                       # ISO YYYY-MM-DD
+    invoice_no: str
+    items: list[tuple[str, float]]
+    currency: str = "USD"
+    total: float | None = None      # if None, computed as sum(items); set explicitly to force a mismatch
+    fmt: str = "JPEG"               # JPEG | PNG | PDF
+    rotate: int = 0
+    low_contrast: bool = False
+    # demo bookkeeping (not rendered): what should happen to this file, and why
+    expected: str = "accept"        # accept | drop | reject
+    reason: str = ""
+
+    def computed_total(self) -> float:
+        return round(sum(amt for _, amt in self.items), 2) if self.total is None else self.total
+
+
+# --- clean receipts: pass all three phases (varied file formats) ------------
+CLEAN: list[Receipt] = [
+    Receipt("receipt_coffee.webp", "Blue Bottle Coffee", "2026-03-12", "BB-1001",
+            [("Latte", 5.50), ("Croissant", 4.25)], fmt="WEBP", low_contrast=True),
+    Receipt("receipt_office.bmp", "Staples", "2026-01-20", "ST-2002",
+            [("Printer Paper", 12.99), ("Gel Pens", 6.50), ("Stapler", 14.00)], fmt="BMP"),
+    Receipt("receipt_lunch.pdf", "Sweetgreen", "2025-11-05", "SG-3003",
+            [("Harvest Bowl", 13.95), ("Lemonade", 3.50)], fmt="PDF"),
+    # multi-page PDF: items on page 1, total on page 2 — exercises page stacking
+    Receipt("receipt_hardware.pdf", "Home Depot", "2026-02-28", "HD-4004",
+            [("Cordless Drill", 89.00), ("Wood Screws", 7.49)], fmt="PDF2"),
+]
+
+# --- business-rule failures: extracted in Phase 2, rejected in Phase 3 ------
+REJECTS: list[Receipt] = [
+    Receipt("receipt_mathbad.tiff", "Quick Mart", "2026-03-01", "QM-5005",
+            [("Soda", 2.00), ("Chips", 3.00)], total=12.00, fmt="TIFF",
+            expected="reject", reason="total != sum(line items)"),
+    Receipt("receipt_future.jpg", "Cafe Tomorrow", "2027-08-01", "CF-6006",
+            [("Green Tea", 4.00)], fmt="JPEG",
+            expected="reject", reason="future-dated"),
+    Receipt("receipt_euro.jpg", "Paris Bistro", "2026-04-10", "PB-7007",
+            [("Plat du Jour", 24.00)], currency="EUR", fmt="JPEG",
+            expected="reject", reason="non-USD currency"),
+    Receipt("receipt_dupinv.jpg", "Quick Mart", "2026-03-02", "QM-5005",
+            [("Bottled Water", 1.50)], fmt="JPEG",
+            expected="reject", reason="duplicate invoice number (QM-5005)"),
+    Receipt("receipt_lux.jpg", "Lux Grand Hotel", "2026-05-01", "LH-8008",
+            [("Executive Suite", 600.00)], fmt="JPEG",
+            expected="reject", reason=f"total exceeds policy cap ${POLICY_CAP_USD:.0f}"),
+]
+
+
+def _font(size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    try:
+        return ImageFont.load_default(size=size)
+    except TypeError:  # very old Pillow
+        return ImageFont.load_default()
+
+
+def render_receipt(r: Receipt) -> Image.Image:
+    """Render a receipt-like image from a Receipt spec."""
+    W, H = 520, 720
+    bg = 210 if r.low_contrast else 255
+    fg = (120, 120, 120) if r.low_contrast else (10, 10, 10)
+    img = Image.new("RGB", (W, H), (bg, bg, bg))
+    d = ImageDraw.Draw(img)
+
+    head, body, small = _font(30), _font(22), _font(18)
+    y = 28
+    d.text((W // 2 - len(r.vendor) * 8, y), r.vendor, fill=fg, font=head); y += 50
+    d.text((30, y), f"Invoice: {r.invoice_no}", fill=fg, font=small); y += 28
+    d.text((30, y), f"Date:    {r.date}", fill=fg, font=small); y += 40
+    d.line([(30, y), (W - 30, y)], fill=fg, width=2); y += 20
+
+    for name, amt in r.items:
+        d.text((40, y), name, fill=fg, font=body)
+        d.text((W - 150, y), f"{r.currency} {amt:,.2f}", fill=fg, font=body)
+        y += 34
+    y += 10
+    d.line([(30, y), (W - 30, y)], fill=fg, width=2); y += 20
+    d.text((40, y), "TOTAL", fill=fg, font=head)
+    d.text((W - 200, y), f"{r.currency} {r.computed_total():,.2f}", fill=fg, font=head)
+
+    d.text((30, H - 50), "Thank you for your business!", fill=fg, font=small)
+    if r.rotate:
+        img = img.rotate(r.rotate, expand=True, fillcolor=(bg, bg, bg))
+    return img
+
+
+def _save(img: Image.Image, path: str, fmt: str) -> None:
+    if fmt == "PDF":
+        img.convert("RGB").save(path, "PDF", resolution=150.0)
+    elif fmt == "PDF2":
+        # split into two pages -> multi-page PDF (total lands on page 2)
+        w, h = img.size
+        top, bottom = img.crop((0, 0, w, h // 2)), img.crop((0, h // 2, w, h))
+        top.convert("RGB").save(
+            path, "PDF", save_all=True, append_images=[bottom.convert("RGB")], resolution=150.0
+        )
+    elif fmt == "PNG":
+        img.save(path, "PNG")
+    elif fmt in ("WEBP", "TIFF", "BMP"):
+        img.convert("RGB").save(path, fmt)
+    else:
+        img.convert("RGB").save(path, "JPEG", quality=88)
+
+
+def generate(out_dir: str) -> dict:
+    """Write the messy inbox to ``out_dir`` and return a manifest of expected outcomes."""
+    os.makedirs(out_dir, exist_ok=True)
+    manifest: list[dict] = []
+
+    def record(filename: str, expected: str, reason: str) -> None:
+        manifest.append({"file": filename, "expected": expected, "reason": reason})
+
+    for r in CLEAN + REJECTS:
+        _save(render_receipt(r), os.path.join(out_dir, r.filename), r.fmt)
+        record(r.filename, r.expected, r.reason)
+
+    # Phase 1 triage targets:
+    # 1) exact duplicate of a clean receipt
+    dup_src, dup_dst = "receipt_coffee.webp", "receipt_coffee_copy.webp"
+    with open(os.path.join(out_dir, dup_src), "rb") as f:
+        data = f.read()
+    with open(os.path.join(out_dir, dup_dst), "wb") as f:
+        f.write(data)
+    record(dup_dst, "drop", f"exact duplicate of {dup_src}")
+
+    # 4) an unsupported / non-image file (can't be decoded -> dropped in triage)
+    with open(os.path.join(out_dir, "notes.txt"), "w", encoding="utf-8") as f:
+        f.write("remember to file the Q1 expense report\n")
+    record("notes.txt", "drop", "unsupported / non-image file")
+
+    # 2) a corrupt/unreadable "image"
+    with open(os.path.join(out_dir, "receipt_corrupt.jpg"), "wb") as f:
+        f.write(b"\xff\xd8\xff\xe0NOT_A_REAL_JPEG\x00\x01\x02broken")
+    record("receipt_corrupt.jpg", "drop", "corrupt / unreadable file")
+
+    # 3) a non-receipt photo
+    photo = Image.new("RGB", (640, 420), (90, 150, 220))
+    pd = ImageDraw.Draw(photo)
+    pd.ellipse([(420, 40), (560, 180)], fill=(250, 230, 120))          # "sun"
+    pd.rectangle([(0, 300), (640, 420)], fill=(230, 210, 150))         # "beach"
+    pd.text((40, 40), "Beach Vacation 2026", fill=(255, 255, 255), font=_font(34))
+    photo.save(os.path.join(out_dir, "beach_photo.png"), "PNG")
+    record("beach_photo.png", "drop", "not a receipt")
+
+    summary = {
+        "policy_cap_usd": POLICY_CAP_USD,
+        "total_files": len(manifest),
+        "accept": sum(1 for m in manifest if m["expected"] == "accept"),
+        "drop": sum(1 for m in manifest if m["expected"] == "drop"),
+        "reject": sum(1 for m in manifest if m["expected"] == "reject"),
+        "files": manifest,
+    }
+    with open(os.path.join(out_dir, "_expected_manifest.json"), "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+    return summary
+
+
+def main() -> None:
+    out = sys.argv[1] if len(sys.argv) > 1 else "./sample_inbox"
+    summary = generate(out)
+    print(f"Wrote {summary['total_files']} files to {out}")
+    print(f"  accept={summary['accept']}  drop={summary['drop']}  reject={summary['reject']}")
+    for m in summary["files"]:
+        tag = m["expected"].upper()
+        print(f"  [{tag:<6}] {m['file']}" + (f"  — {m['reason']}" if m["reason"] else ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/validation.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/validation.py
@@ -1,0 +1,229 @@
+"""Three-phase validation for the receipts → ledger demo.
+
+Phases (progressive, mirroring the SDK demo's structure):
+
+- **Phase 1 — Triage (structural):** each inbox file is readable, a real receipt,
+  and not an exact duplicate. Failures here mean the file is *dropped*.
+- **Phase 2 — Extract (multimodal):** every kept file yields the required fields
+  (vendor, date, total, currency). Missing fields fail extraction.
+- **Phase 3 — Validate (business rules):** total == sum(line items), date parseable
+  and not future / not older than 2023, currency == USD, invoice number unique, and
+  total within the policy cap. Failures here mean the row is *rejected* (with reason).
+
+This module is pure Python (only ``python-dateutil``) so it runs identically on the
+host and inside the E2B sandbox, and is unit-tested without live services.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+
+from dateutil import parser as dateparser
+
+PHASE_NAMES = {
+    1: "Triage (structural)",
+    2: "Extract (multimodal)",
+    3: "Validate (business rules)",
+}
+
+POLICY_CAP_USD = 500.00
+MIN_YEAR = 2023
+AMOUNT_TOLERANCE = 0.01
+
+
+@dataclass
+class FileOutcome:
+    """Final disposition of a single inbox file."""
+    source_file: str
+    outcome: str                 # "accepted" | "rejected" | "dropped"
+    phase: int                   # phase that decided the outcome (3 for accepted)
+    reason: str = ""
+    record: dict | None = None   # extracted fields, when available
+
+    def to_dict(self) -> dict:
+        return {
+            "source_file": self.source_file,
+            "outcome": self.outcome,
+            "phase": self.phase,
+            "reason": self.reason,
+            "record": self.record,
+        }
+
+
+def _parse_amount(value) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(str(value).replace(",", "").replace("$", "").strip())
+    except ValueError:
+        return None
+
+
+def check_business_rules(
+    record: dict,
+    *,
+    today: date,
+    seen_invoice_nos: set[str],
+    policy_cap: float = POLICY_CAP_USD,
+) -> list[str]:
+    """Return a list of business-rule failure reasons for an extracted record (empty = pass).
+
+    ``seen_invoice_nos`` is the set of invoice numbers already accepted; this call does
+    NOT mutate it (the caller adds the invoice number only once a row is accepted).
+    """
+    reasons: list[str] = []
+
+    vendor = (record.get("vendor") or "").strip()
+    currency = (record.get("currency") or "").strip().upper()
+    invoice_no = (record.get("invoice_no") or "").strip()
+    total = _parse_amount(record.get("total"))
+    items = record.get("line_items") or []
+
+    # Required fields (a Phase-2 concern, re-checked defensively here).
+    if not vendor:
+        reasons.append("missing vendor")
+    if total is None:
+        reasons.append("missing or unparseable total")
+
+    # total == sum(line items)
+    if total is not None and items:
+        item_sum = 0.0
+        ok = True
+        for it in items:
+            amt = _parse_amount(it.get("amount") if isinstance(it, dict) else None)
+            if amt is None:
+                ok = False
+                break
+            item_sum += amt
+        if ok and abs(item_sum - total) > AMOUNT_TOLERANCE:
+            reasons.append(f"total {total:.2f} != sum(line items) {item_sum:.2f}")
+
+    # date sanity
+    raw_date = (record.get("date") or "").strip()
+    if not raw_date:
+        reasons.append("missing date")
+    else:
+        try:
+            parsed = dateparser.parse(raw_date).date()
+            if parsed > today:
+                reasons.append(f"future-dated ({parsed.isoformat()})")
+            elif parsed.year < MIN_YEAR:
+                reasons.append(f"stale date ({parsed.isoformat()}, before {MIN_YEAR})")
+        except (ValueError, OverflowError, TypeError):
+            reasons.append(f"unparseable date ({raw_date!r})")
+
+    # currency
+    if currency and currency != "USD":
+        reasons.append(f"non-USD currency ({currency})")
+    elif not currency:
+        reasons.append("missing currency")
+
+    # policy cap
+    if total is not None and total > policy_cap:
+        reasons.append(f"total {total:.2f} exceeds policy cap {policy_cap:.2f}")
+
+    # duplicate invoice number
+    if invoice_no and invoice_no in seen_invoice_nos:
+        reasons.append(f"duplicate invoice number ({invoice_no})")
+
+    return reasons
+
+
+@dataclass
+class ValidationResult:
+    passed: bool
+    summary: str
+    failed_phase: int | None
+    inbox_files: list[str]
+    outcomes: list[FileOutcome] = field(default_factory=list)
+
+    @property
+    def accepted(self) -> list[FileOutcome]:
+        return [o for o in self.outcomes if o.outcome == "accepted"]
+
+    def to_dict(self) -> dict:
+        return {
+            "status": "passed" if self.passed else "failed",
+            "summary": self.summary,
+            "failed_phase": self.failed_phase,
+            "inbox_file_count": len(self.inbox_files),
+            "accepted": len(self.accepted),
+            "rejected": sum(1 for o in self.outcomes if o.outcome == "rejected"),
+            "dropped": sum(1 for o in self.outcomes if o.outcome == "dropped"),
+            "outcomes": [o.to_dict() for o in self.outcomes],
+        }
+
+
+def validate_ledger(
+    inbox_files: list[str],
+    outcomes: list[FileOutcome],
+    *,
+    require_nonempty: bool = True,
+) -> ValidationResult:
+    """Validate completeness + correctness of a fully-processed inbox.
+
+    A run *passes* only when:
+      - every inbox file is accounted for exactly once (accepted / rejected / dropped),
+      - at least one row was accepted (unless ``require_nonempty`` is False),
+      - no accepted row carries a business-rule reason.
+
+    This is what the pre-merge gate ultimately enforces (via the serialized result).
+    """
+    by_file: dict[str, list[FileOutcome]] = {}
+    for o in outcomes:
+        by_file.setdefault(o.source_file, []).append(o)
+
+    inbox = set(inbox_files)
+    decided = set(by_file)
+
+    missing = sorted(inbox - decided)
+    unexpected = sorted(decided - inbox)
+    duplicated = sorted(f for f, lst in by_file.items() if len(lst) > 1)
+
+    if missing or unexpected or duplicated:
+        problems = []
+        if missing:
+            problems.append(f"{len(missing)} unaccounted ({', '.join(missing[:3])}…)" if len(missing) > 3 else f"unaccounted: {', '.join(missing)}")
+        if unexpected:
+            problems.append(f"unexpected: {', '.join(unexpected)}")
+        if duplicated:
+            problems.append(f"double-counted: {', '.join(duplicated)}")
+        return ValidationResult(
+            passed=False,
+            summary="incomplete accounting — " + "; ".join(problems),
+            failed_phase=1,
+            inbox_files=inbox_files,
+            outcomes=outcomes,
+        )
+
+    accepted = [o for o in outcomes if o.outcome == "accepted"]
+    bad_accepted = [o for o in accepted if o.reason]
+    if bad_accepted:
+        return ValidationResult(
+            passed=False,
+            summary=f"{len(bad_accepted)} accepted row(s) still carry failures",
+            failed_phase=3,
+            inbox_files=inbox_files,
+            outcomes=outcomes,
+        )
+
+    if require_nonempty and not accepted:
+        return ValidationResult(
+            passed=False,
+            summary="no receipts accepted — ledger is empty",
+            failed_phase=2,
+            inbox_files=inbox_files,
+            outcomes=outcomes,
+        )
+
+    n_rej = sum(1 for o in outcomes if o.outcome == "rejected")
+    n_drop = sum(1 for o in outcomes if o.outcome == "dropped")
+    return ValidationResult(
+        passed=True,
+        summary=f"{len(accepted)} accepted, {n_rej} rejected, {n_drop} dropped — ledger valid",
+        failed_phase=None,
+        inbox_files=inbox_files,
+        outcomes=outcomes,
+    )

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/template/e2b.Dockerfile
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/template/e2b.Dockerfile
@@ -1,0 +1,32 @@
+# Custom E2B template for the receipts-ledger agent.
+#
+# Bakes the slow, stable pieces so each run starts fast:
+#   - FUSE userspace (so `everest mount --protocol fuse` works)
+#   - the everest (lakeFS Mount) Linux binary
+#   - the agent's python deps
+#
+# The agent package itself is NOT baked — the orchestrator uploads it fresh each run,
+# and /dev/fuse permissions are set per-sandbox at runtime by provision().
+#
+# Build context = this directory. Before building, copy the gitignored Linux binary here:
+#   cp ../build/bin/everest ./everest
+# Then:  e2b template build --name mount-receipts
+FROM e2bdev/code-interpreter:latest
+
+# System packages need root (the base image's default build user is non-root).
+USER root
+
+# FUSE userspace
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends fuse3 \
+ && rm -rf /var/lib/apt/lists/* \
+ && echo user_allow_other >> /etc/fuse.conf
+
+# everest binary (lakeFS Mount). Provided in the build context (see header).
+COPY everest /usr/local/bin/everest
+RUN chmod +x /usr/local/bin/everest
+
+# Agent python dependencies — installed system-wide (as root) so the agent, which runs
+# as root (so the FUSE mount is visible to E2B's root-owned envd / Filesystem tab), can
+# import them. Installing as the 'user' would put them in ~/.local, unreachable by root.
+RUN pip install --no-cache-dir openai pillow pymupdf python-dateutil

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/template/e2b.toml
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/template/e2b.toml
@@ -1,0 +1,18 @@
+# This is a config for E2B sandbox template.
+# Build your own template from the e2b.Dockerfile in this directory:
+#   e2b template build --name mount-receipts
+# E2B then fills in your own team_id and template_id below. The values here are placeholders.
+
+# Python SDK
+# from e2b import Sandbox, AsyncSandbox
+# sandbox = Sandbox.create("mount-receipts") # Sync sandbox
+# sandbox = await AsyncSandbox.create("mount-receipts") # Async sandbox
+
+# JS SDK
+# import { Sandbox } from 'e2b'
+# const sandbox = await Sandbox.create('mount-receipts')
+
+team_id = "your-e2b-team-id"
+dockerfile = "e2b.Dockerfile"
+template_name = "mount-receipts"
+template_id = "your-template-id"

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/tests/test_validation.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/tests/test_validation.py
@@ -1,0 +1,122 @@
+"""Unit tests for the receipts ledger validation (no live services needed)."""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from mount_receipts.validation import (
+    FileOutcome,
+    check_business_rules,
+    validate_ledger,
+)
+
+TODAY = date(2026, 6, 5)
+
+
+def _rec(**kw):
+    base = dict(
+        vendor="Acme",
+        invoice_no="A-1",
+        date="2026-01-10",
+        currency="USD",
+        line_items=[{"name": "x", "amount": 4.0}, {"name": "y", "amount": 6.0}],
+        total=10.0,
+    )
+    base.update(kw)
+    return base
+
+
+# --- business rules --------------------------------------------------------
+
+def test_clean_record_passes():
+    assert check_business_rules(_rec(), today=TODAY, seen_invoice_nos=set()) == []
+
+
+def test_total_mismatch():
+    reasons = check_business_rules(_rec(total=12.0), today=TODAY, seen_invoice_nos=set())
+    assert any("sum(line items)" in r for r in reasons)
+
+
+def test_future_date():
+    reasons = check_business_rules(_rec(date="2027-08-01"), today=TODAY, seen_invoice_nos=set())
+    assert any("future-dated" in r for r in reasons)
+
+
+def test_stale_date():
+    reasons = check_business_rules(_rec(date="2019-01-01", total=10.0), today=TODAY, seen_invoice_nos=set())
+    assert any("stale date" in r for r in reasons)
+
+
+def test_non_usd():
+    reasons = check_business_rules(_rec(currency="EUR"), today=TODAY, seen_invoice_nos=set())
+    assert any("non-USD" in r for r in reasons)
+
+
+def test_over_cap():
+    reasons = check_business_rules(
+        _rec(line_items=[{"name": "suite", "amount": 600.0}], total=600.0),
+        today=TODAY, seen_invoice_nos=set(),
+    )
+    assert any("policy cap" in r for r in reasons)
+
+
+def test_duplicate_invoice():
+    reasons = check_business_rules(_rec(invoice_no="DUP"), today=TODAY, seen_invoice_nos={"DUP"})
+    assert any("duplicate invoice" in r for r in reasons)
+
+
+def test_amounts_as_strings_are_parsed():
+    rec = _rec(total="$10.00", line_items=[{"name": "x", "amount": "4.00"}, {"name": "y", "amount": "6.00"}])
+    assert check_business_rules(rec, today=TODAY, seen_invoice_nos=set()) == []
+
+
+# --- ledger completeness ---------------------------------------------------
+
+def _acc(f):  # accepted
+    return FileOutcome(f, "accepted", 3, "", _rec())
+
+
+def test_full_accounting_passes():
+    inbox = ["a.jpg", "b.jpg", "c.jpg"]
+    outcomes = [
+        _acc("a.jpg"),
+        FileOutcome("b.jpg", "rejected", 3, "non-USD currency"),
+        FileOutcome("c.jpg", "dropped", 1, "corrupt"),
+    ]
+    res = validate_ledger(inbox, outcomes)
+    assert res.passed, res.summary
+    assert res.failed_phase is None
+
+
+def test_unaccounted_file_fails():
+    res = validate_ledger(["a.jpg", "b.jpg"], [_acc("a.jpg")])
+    assert not res.passed
+    assert res.failed_phase == 1
+    assert "unaccounted" in res.summary
+
+
+def test_double_counted_fails():
+    outcomes = [_acc("a.jpg"), FileOutcome("a.jpg", "dropped", 1, "dup")]
+    res = validate_ledger(["a.jpg"], outcomes)
+    assert not res.passed
+    assert "double-counted" in res.summary
+
+
+def test_accepted_with_reason_fails():
+    bad = FileOutcome("a.jpg", "accepted", 3, "non-USD currency", _rec(currency="EUR"))
+    res = validate_ledger(["a.jpg"], [bad])
+    assert not res.passed
+    assert res.failed_phase == 3
+
+
+def test_empty_ledger_fails():
+    res = validate_ledger(["a.jpg"], [FileOutcome("a.jpg", "dropped", 1, "corrupt")])
+    assert not res.passed
+    assert res.failed_phase == 2
+
+
+def test_unexpected_file_fails():
+    res = validate_ledger(["a.jpg"], [_acc("a.jpg"), _acc("ghost.jpg")])
+    assert not res.passed
+    assert "unexpected" in res.summary

--- a/01_standalone_examples/e2b/uv.lock
+++ b/01_standalone_examples/e2b/uv.lock
@@ -1,0 +1,1166 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[manifest]
+members = [
+    "data-agent-demo",
+    "lakefs-e2b-common",
+    "lakefs-e2b-poc",
+    "mount-receipts",
+]
+
+[[package]]
+name = "aenum"
+version = "3.1.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/e9/8b283567c1fef7c24d1f390b37daede8b61593d8cdaffb8e95d571699e83/aenum-3.1.17.tar.gz", hash = "sha256:a969a4516b194895de72c875ece355f17c0d272146f7fda346ef74f93cf4d5ba", size = 137648, upload-time = "2026-03-20T20:43:29.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/8d/1fe30c6fd8999b9d462547c4a1bb6690bda24af38f2913c4bec7decb81f2/aenum-3.1.17-py3-none-any.whl", hash = "sha256:8b883a37a04e74cc838ac442bdd28c266eae5bbf13e1342c7ef123ed25230139", size = 165560, upload-time = "2026-03-20T20:43:27.681Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.23"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/7e/18f6d87625930231708681ccfba20c2c6ade8d977c37d388992c0589efdd/boto3-1.43.23.tar.gz", hash = "sha256:5d26498702ffd021dc0d57d0eefcc7101cd995ea0ed08c057c9b631efccbaa48", size = 113242, upload-time = "2026-06-04T19:39:37.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/1e/27b67ee4d10cc755aa9a35d45aa476d7bb2366c4dea91b0db94fa0fe27bd/boto3-1.43.23-py3-none-any.whl", hash = "sha256:8afc058924ef8a5c62467fe2e1e2e0304c22018587a044714da89f9c602ba856", size = 140536, upload-time = "2026-06-04T19:39:34.657Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.23"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/79/9c3313d8be64ebff5a100d73777d5c6249229ceee57e269a0830b2f7d3a3/botocore-1.43.23.tar.gz", hash = "sha256:a6737c598750f330bfa8ef2be2d9fa84b5d2d643b6bbb0d22e129e03b7535df1", size = 15464775, upload-time = "2026-06-04T19:39:26.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/0e/63e4720c6fe6dab278faf9f09b59c377e49a9f9a1afaec2c69dc2e7b9de2/botocore-1.43.23-py3-none-any.whl", hash = "sha256:69ff3d951cb644d1d84db646663c7eb919dc9c0c47e5768e947c8a71121b3d77", size = 15147962, upload-time = "2026-06-04T19:39:22.141Z" },
+]
+
+[[package]]
+name = "bracex"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "data-agent-demo"
+version = "0.2.0"
+source = { editable = "usecases/02-three-phase-repair" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "e2b" },
+    { name = "lakefs" },
+    { name = "lakefs-e2b-common" },
+    { name = "openai" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "pytest" },
+    { name = "python-dateutil" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "boto3", specifier = ">=1.28.0" },
+    { name = "botocore", specifier = ">=1.31.0" },
+    { name = "e2b", specifier = ">=1.0.0" },
+    { name = "lakefs" },
+    { name = "lakefs-e2b-common", editable = "shared" },
+    { name = "openai", specifier = ">=1.0.0" },
+    { name = "pandas", specifier = ">=2.0.0" },
+    { name = "pyarrow", specifier = ">=12.0.0" },
+    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "python-dateutil", specifier = ">=2.8.0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "rich", specifier = ">=13.0.0" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "dockerfile-parse"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/df/929ee0b5d2c8bd8d713c45e71b94ab57c7e11e322130724d54f469b2cd48/dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc", size = 24556, upload-time = "2023-07-18T13:36:07.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/6c/79cd5bc1b880d8c1a9a5550aa8dacd57353fa3bb2457227e1fb47383eb49/dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6", size = 14845, upload-time = "2023-07-18T13:36:06.052Z" },
+]
+
+[[package]]
+name = "e2b"
+version = "2.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "dockerfile-parse" },
+    { name = "h2" },
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "python-dateutil" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/07/97604da2a7b7db68b970bab60d1bbffa436e73492c000d1889daf6283cf6/e2b-2.25.1.tar.gz", hash = "sha256:b87f8da3bbcce613e1bef9a90c46ef042a053f3f311b5ab45fcff5bdf1b1b425", size = 163032, upload-time = "2026-05-29T23:45:55.756Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/d5/d04b038ffb56ff6ba76cf6c2438908336aa58a5eb405b2fa191d398106c5/e2b-2.25.1-py3-none-any.whl", hash = "sha256:5ea5d1766082c1db504f86ebe17abe8b6a07f33d8addfb1a7778fae4a9549891", size = 309607, upload-time = "2026-05-29T23:45:54.327Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/13/daa722f5765c393576f466378f9dfd29d77c9bed939e0688f96afa3601ea/jiter-0.15.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0f862193b8696249d22ec433e85fd2ab0ad9596bc3e45e6c0bc55e8aeba97be2", size = 310899, upload-time = "2026-05-19T10:07:12.89Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/82/2d2551829b082f4b6d82b9f939b031fb808a10aab1ec0664f82e150bb9a2/jiter-0.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1303d4d68a9b051ea90502402063ecf3807da00ad2affa19ca1ae3b90b3c5f67", size = 314963, upload-time = "2026-05-19T10:07:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0a/8b1a51466f7fe9f31dbe4bc7e0ca848674f9825e0f737b929b97e8c60aa7/jiter-0.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:392b8ab019e5502d08aff85c6272209c24bc2cbe706ea82a56368f524236614a", size = 341730, upload-time = "2026-05-19T10:07:15.869Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/2a/e71dea19822e2e404e83992a08c1d6b9b617bb944f28c9c2fbd85d02c91e/jiter-0.15.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:773b6eb282ce11ee19f05f6b2d4404fa308e5bbd353b0b80a0262caad6db2cd7", size = 366214, upload-time = "2026-05-19T10:07:17.259Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/97e1fa539d124a509a00ab7f669289d1c1d236ecabf12948a18f16c91082/jiter-0.15.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d2c0c44d569ce0f2850f5c926f8caeb5f245fbc84475aeb36efccc2103e6dbd", size = 459527, upload-time = "2026-05-19T10:07:18.741Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7a/4a68d331aef8cf2e2393c14a3aacb635c62aa86071b0229899fb5baaa907/jiter-0.15.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:032396229564bca02440396bd327710719f724f5e7b7e9f7a8eb3faa4a2c2281", size = 375451, upload-time = "2026-05-19T10:07:20.208Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/1c445c2b6f0e30a274dc8082e0c3c7825411cce80d726bccd697c98cc8d3/jiter-0.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3d37768fce7f88dd2a8c6091f2325dea27d30d30d5c6e7a1c0f0af77723b708", size = 349428, upload-time = "2026-05-19T10:07:22.372Z" },
+    { url = "https://files.pythonhosted.org/packages/00/94/e20d38984fc17a636371bffd2ae0f698124fdc8e75ef969cd2da6ba7cea7/jiter-0.15.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:2c9cb907439d20bd0c7d7565ca01ee52234203208433749bae5b516907526928", size = 355405, upload-time = "2026-05-19T10:07:23.916Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fa/4d09f814779d0ea80a28ed8e4c6662ec9a4a8ecef0ac52190ebac6262d14/jiter-0.15.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9100ddbec09741cc66feb0fc6773f8bdbd0e3c345689368f260082ff85dcc0cd", size = 393688, upload-time = "2026-05-19T10:07:25.854Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9d/8eb5d4fb8bf7e93a75964a5da71a75c67c864baf7fa3f98598187b3c7e57/jiter-0.15.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ae1b0d82ac2d987f9ea512b1c9adfcc71a28de3dea3a6039b54d76cffda9901e", size = 520853, upload-time = "2026-05-19T10:07:27.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2c/5e07874e59e623a943a0acf1552a80d05b70f31b402287a8fc6d7ec634c7/jiter-0.15.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8020c99ec13a7db2b6f96cbe82ef4721c88b426a4892f27478044af0284615ef", size = 551016, upload-time = "2026-05-19T10:07:28.846Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/d2d34422143474cadc15b60d482b1c35683dbc5c63c24346ddd0df09bcaf/jiter-0.15.0-cp311-cp311-win32.whl", hash = "sha256:42bfb257930800cf43e7c62c832402c704ab60797c992faf88d20e903eac8f32", size = 209518, upload-time = "2026-05-19T10:07:30.431Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/7d/52778b930e5cc3e52a37d950b1c10494244308b4329b25a0ff0d88303a81/jiter-0.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:860a74063284a2ae9bfedd694f299cc2c68e2696c5f3d440cc9d18bb81b9dd04", size = 200565, upload-time = "2026-05-19T10:07:32.125Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4f/d9b4067feb69b3fa6eb0488e1b59e2ad5b463fe39f59e527eab2aca00bb0/jiter-0.15.0-cp311-cp311-win_arm64.whl", hash = "sha256:37a10c377ce3a4a85f4a67f28b7afe093154cde77eaf248a72e856aa08b4d865", size = 195488, upload-time = "2026-05-19T10:07:33.846Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793, upload-time = "2026-05-19T10:07:35.25Z" },
+    { url = "https://files.pythonhosted.org/packages/01/84/c01099b59a285a1ebba64ae93f62bfa036675340fd1b0045ae65890a0442/jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c9004af7c8d67cce7f1aae1026fb55607f4aa600710d08ede3a3ce4aeefe7e0", size = 309570, upload-time = "2026-05-19T10:07:36.919Z" },
+    { url = "https://files.pythonhosted.org/packages/58/64/8fb7f9d45bb98190355454cd04dad8d8f27223d6bd52f83af07f637168a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c210f8b35dc6f30aafd4b4365ca89b9d1189f21ab49b8e68fa6322a847aef138", size = 336783, upload-time = "2026-05-19T10:07:38.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b6/f5739011d009b3a30f6a53c5240979030ba29ae46a8c67e3a15759f7c37d/jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61", size = 363555, upload-time = "2026-05-19T10:07:40.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/12/98a9d9f766665e8a3b6252454e17cb0c464606a28cf2fa09399b003345fa/jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687", size = 452255, upload-time = "2026-05-19T10:07:42.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d5/60f972840f79c5e7544fce567c56f1e4e50468f996baba3e78d823dd62a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879", size = 373559, upload-time = "2026-05-19T10:07:44.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d", size = 346055, upload-time = "2026-05-19T10:07:46.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/63/4d2749d8d54d230bad9b3a6b0d00cc28c6ff6b2fdffc26a8ccf76cc5a974/jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb", size = 351406, upload-time = "2026-05-19T10:07:47.855Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b9/9965b990035d8773328e0a8c8b457a87bf2b19f6c4126d9d99296be5d16a/jiter-0.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ae901f3a55bfafdde31d289590fa25e3245735a2b1e8c7cc15871710a002871", size = 389357, upload-time = "2026-05-19T10:07:49.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/55/9ddf903deda1413e87fed792f416b7123daee5b8efbad6a202a7421c36a5/jiter-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f0b271b462769543716f92d3a4f90527df6ef5ed05ee95ec4137f513e21e1b77", size = 517263, upload-time = "2026-05-19T10:07:51.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/76/a0c40ad064d3a20a4fde231e35d56e9a01ce82164278180e82d5daf85469/jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d", size = 548646, upload-time = "2026-05-19T10:07:53.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4f/eca9b954942916ba2f453891b8593ab444cd872396fe66a3936616f236f3/jiter-0.15.0-cp312-cp312-win32.whl", hash = "sha256:c2f6bb8b5216ab9e7873bc08b5d7bef2b8abbb578a3069bf1cd14a45d71d771d", size = 206427, upload-time = "2026-05-19T10:07:55.307Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/8ead82a87495149542748e828d153fd232a512a22c83b02c4815c1a9c7d8/jiter-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:40b2c7e92c44a84d748d21706c68dc6ff8161d80b59c99d774721a0d2317d7c7", size = 197300, upload-time = "2026-05-19T10:07:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e4/9b8a78fb2d894471bc344e37f1949bdd784bd914d031dba0ba3a40c71dd7/jiter-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:cc0bc345cf2df9d1c00ac443f50d543c1ccfa8b0422cb85b1ab70d681c0b255b", size = 192702, upload-time = "2026-05-19T10:07:58.307Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f4/f708c900ecee41b2025ef8413d5351e5649eb2125c506f6720cc69b06f5c/jiter-0.15.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c11465f97e2abf45a014b83b730222f8f1c5335e802c7055a67d50de6f1f4e3", size = 307829, upload-time = "2026-05-19T10:07:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/db537c0949e83668c38481d426b9f2fd5ab758c4ee53a811dd0a510626a0/jiter-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e7b1776f0797956c509e123d0952d10d293a9492dea9f288ab9570ec01d1a5", size = 308445, upload-time = "2026-05-19T10:08:01.184Z" },
+    { url = "https://files.pythonhosted.org/packages/37/38/ea0e13b18c30ef951da0d47d39e7fa9edb82a93a62990ffbd7cea9b622d4/jiter-0.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351a341c2105aa430b7047e30f1bf7975f6313b00165d3fc07be2edaf741f279", size = 336181, upload-time = "2026-05-19T10:08:02.688Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fc/2303901b16c4ba05865588990a420c0b4156270b44379c20931544a1d962/jiter-0.15.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ab395feec8d249ec4044e228e98a7033f043426a265df439dc3698823f0a4e4", size = 362985, upload-time = "2026-05-19T10:08:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/11bace093c52e7d4d26c8e606ccd7ae8c972189622469ec0d9e28161e28b/jiter-0.15.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2a438005b6f22d0273413484d6094d7c2c5d10ec1b3a3bf128e0d1d3ba53258", size = 453292, upload-time = "2026-05-19T10:08:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/22/db/987f2f086ca4d7a6582eb4ccd513f9b26b42d9e4243a087609a3137a8fc7/jiter-0.15.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f18f85e4218d1b40f000f42a92239a7a61a902cd42c65e6c360dbd17dcb20894", size = 373501, upload-time = "2026-05-19T10:08:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/89fbcabb2739b7a5b8dc959a1b6c5761f6484f5fed3486854b3c789bb1de/jiter-0.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1aa62e277fc1cbd80e6deacae6f4d983b41b3d7728e0645c5d741a6149bba45", size = 344683, upload-time = "2026-05-19T10:08:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/6cca7692e7dddfec6d8d76c54dc97f2af2a41df4ac0674b999df1f09a5f3/jiter-0.15.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:6550fa135c7deb8ead6af49ed7ff648532ea8334a1447fe34a36315ef79c5c29", size = 350892, upload-time = "2026-05-19T10:08:11.352Z" },
+    { url = "https://files.pythonhosted.org/packages/39/14/0338d6190cb8e6d22e677ab1d4eabd4117f67cca70c54cd04b82ff64e068/jiter-0.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:066f8f33f18b2419cd8213b2436fa7fbc9c499f315971cfa3ce1f9820c001b1b", size = 388723, upload-time = "2026-05-19T10:08:12.912Z" },
+    { url = "https://files.pythonhosted.org/packages/90/31/cc19f4a1bdb6afb09ce6a2f2615aa8d44d994eba0d8e6105ed1af920e736/jiter-0.15.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:75e8a04e91432dde9f1838373cf93d23726c79d3e908d319acf0e796f85592e7", size = 516648, upload-time = "2026-05-19T10:08:14.808Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9f/833c541512cd091b63c10c0381973dfe11bc7a503a818c16384417e0c81e/jiter-0.15.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a97261f1fccb8e50ecd2890a96e46efdc3f57c80a197324c6777827231eca712", size = 547382, upload-time = "2026-05-19T10:08:16.927Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/11/e7b70e91f90bc4477e8eee9e8a5f7cf3cb41b4525d6394dc98a714eb8f7f/jiter-0.15.0-cp313-cp313-win32.whl", hash = "sha256:c77496cb10bd7549690fbbab3e5ec05857b83e49276f4a9423a766ddd2afcd4c", size = 205845, upload-time = "2026-05-19T10:08:18.401Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/5c20d9ad6f02c493e4023e5d2d09e1c1f15fe2753c9102c544aff068a88e/jiter-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b15741f501469009ae0ae90b7147958a664a7dede40aa7ff174a8a4645f546d0", size = 196842, upload-time = "2026-05-19T10:08:20.131Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/11/1eb400ef248e8c925fd883fbe325daf5e42cd1b0d308539dd332bd4f7ffc/jiter-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d6a60072b44c3c2b797a7ddcbcbbf2b34ea3cfd4721580fbfd2a09d9d9b84ba", size = 192212, upload-time = "2026-05-19T10:08:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/60/2fd8d7c79da8acf9b7b277c7616847773779356b92acfc9bb158452174da/jiter-0.15.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ef1fd24d9413f6209e00d3d5a453e67acfe004a25cc6c8e8484faed4311ab9e8", size = 315065, upload-time = "2026-05-19T10:08:23.218Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f4/008fb7d65e8ac2abf00811651a661e025c4ba80bbc6f378450384ddd3aed/jiter-0.15.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144f8e72cb53dab146347b91cceac01f5481237f2b93b4a339a1ee8f8878b67c", size = 339444, upload-time = "2026-05-19T10:08:24.701Z" },
+    { url = "https://files.pythonhosted.org/packages/00/55/90b0c7b9c6896c0f2a591dd36d36b71d22e09674bfef178fa03ba3f81499/jiter-0.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:553fcac2ef2cb990877f9fc0833b8b629a3e6a5670b6b5fd58219b41a653ddc4", size = 347779, upload-time = "2026-05-19T10:08:26.408Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/69666cec5000fd57734c118437394516c749ae8dbeea9fb66d6fef9c4775/jiter-0.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:774f93f65031856bf14ad9f59bdcab8b8cad501e5ceabd51ba3525f76937a25b", size = 200395, upload-time = "2026-05-19T10:08:28.055Z" },
+    { url = "https://files.pythonhosted.org/packages/39/04/a6aa62cd27e8149b0d28df5561f10f6cceaf7935a9ccf3f1c5a05f9a0cd8/jiter-0.15.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f1e1754960f38ec40613a07e5e372df67acb3b890fb383b6fb3de3e49ddbf3c7", size = 190516, upload-time = "2026-05-19T10:08:29.35Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/079f350ebf7859d081de30aa890f9e3be68516f754f3ba32366ffff4dcee/jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49", size = 308884, upload-time = "2026-05-19T10:08:31.667Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4e/a2c30a7f69b48c03b20935d647479106fe932f6e63f75faf53937197e05d/jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86", size = 310028, upload-time = "2026-05-19T10:08:33.304Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/2e7cdfd3cf8ca967be38c48f5cf474d79f089efaf559a40f15984a77ae69/jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f", size = 337485, upload-time = "2026-05-19T10:08:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/11/15a1aa28b120b8ee5b4f1fb894c125046225f09847738bd64233d3b84883/jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e", size = 364223, upload-time = "2026-05-19T10:08:36.694Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/f442e8af5f3d0dcf47b39e83a0efd9ee45ea946aa6d04625dc3181eae3b6/jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6", size = 456387, upload-time = "2026-05-19T10:08:38.143Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f4/37f2d2c9f64f49af7da652ed7532bb5a2372e588e6927c3fdd76f911db65/jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9", size = 374461, upload-time = "2026-05-19T10:08:39.869Z" },
+    { url = "https://files.pythonhosted.org/packages/60/28/edcfbbbf0cb15436f36664a8908a0df47ab9006298d4cd937dc08ea932d6/jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c", size = 345924, upload-time = "2026-05-19T10:08:41.668Z" },
+    { url = "https://files.pythonhosted.org/packages/47/13/89fba6398dab7f202b7278c4b4aac122399d2c0183971c4a57a3b7088df5/jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd", size = 352283, upload-time = "2026-05-19T10:08:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/da/0f6af8cef2c565a1ab44d970f268c43ccaa72707386ea6388e6fe2b6cd26/jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89", size = 389985, upload-time = "2026-05-19T10:08:44.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/b9cb7d6d29e24ee14910266157d2a279d7a8f60ee0df7fa840882976ba64/jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554", size = 517695, upload-time = "2026-05-19T10:08:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5e/6d1bda880723aae0ad86b4b763f044362448efe31e3e819635d41cb03451/jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a", size = 548868, upload-time = "2026-05-19T10:08:48.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/72/7de501cf38dcacaf35098796f3a50e0f2e338baba18a58946c618544b809/jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec", size = 206380, upload-time = "2026-05-19T10:08:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a9/e19addf4b0c1bdce52c6da12351e6bc42c340c45e7c09e2158e46d293ccc/jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558", size = 197687, upload-time = "2026-05-19T10:08:51.088Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c9/776b1db01db25fc6c1d58d1979a37b0a9fe787e5f5b1d062d2eaacb77923/jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866", size = 192571, upload-time = "2026-05-19T10:08:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f6/45bb4670bacf300fd2c7abadbfb3af376e5f1b6ae75fd9bc069891d15870/jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d", size = 317151, upload-time = "2026-05-19T10:08:53.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/ed635ad5acd7b73e454283083bbb7c8205ad10e88b0d9d7d793b09fe8226/jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6", size = 341243, upload-time = "2026-05-19T10:08:55.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/db/3ff4176b817b8ea33879e71e13d8bc2b0d481a7ed3fe9e080f333d415c16/jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995", size = 363629, upload-time = "2026-05-19T10:08:56.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/24/5f8270e0ba9c883582f96f722f8a0b58015c7ce1f8c6d4571cf394e99b6b/jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8", size = 456198, upload-time = "2026-05-19T10:08:58.618Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5b/76fc02b0b5c54c3d18c60653156e2f76fde1816f9b4722db68d6ee2c897e/jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5", size = 373710, upload-time = "2026-05-19T10:09:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/52/4310821b0ea9277994d3e1f49fc6a4b34e4800caebacb2c0af81da59a454/jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b", size = 349901, upload-time = "2026-05-19T10:09:01.621Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fe/67648c35b3594fba8854ac64cc8a826d8bcd18324bbdb53d77697c60b6ef/jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8", size = 352438, upload-time = "2026-05-19T10:09:03.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/0a1879d07ad6b3e025a2750027363452ced93c2d16d1c9d4b153ffd51c91/jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec", size = 388152, upload-time = "2026-05-19T10:09:04.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/78/46c6f6b56ba85c90021f4afd72ed42f691f8f84daacb5fe27277070e3858/jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e", size = 517707, upload-time = "2026-05-19T10:09:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cb/720662d4c88fcad606e826fef5424365527ba43ce4868a479aed8f8c507e/jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5", size = 548241, upload-time = "2026-05-19T10:09:08.093Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950, upload-time = "2026-05-19T10:09:09.616Z" },
+    { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055, upload-time = "2026-05-19T10:09:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244, upload-time = "2026-05-19T10:09:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/43/1fc62172aa98b50a7de9a25554060db510f85c89cfbed0dfe13e1907a139/jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:411fa4dfa5a7ae3d11491027ffb9beadec3996010a986862db70d91abba1c750", size = 305585, upload-time = "2026-05-19T10:09:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c4/dd58fcd9e2df83666e5c1c1347bef58ce919cd8efc3ffa38aeea62ce493b/jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:2b0074e2f56eb2dacca1689760fd2852a068f85a0547a157b82cb4cafeb6768b", size = 306936, upload-time = "2026-05-19T10:09:37.435Z" },
+    { url = "https://files.pythonhosted.org/packages/39/86/b695e16f1180c07f43ea98e73ecd21cf63fa2e1b0c1103739013784d11ae/jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:913d02d29c9606643418d9ccfc3b72492ab25a6bf7889934e09a3490f8d3438b", size = 342453, upload-time = "2026-05-19T10:09:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/34/56/55d76614af37fe3f22a3347d1e410d2a15da581997cb2da499a625000bb5/jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b15d3ec9b0449c40e85319bdb4caa8b77ab526e74f5532ed94bec15e2f66822c", size = 345606, upload-time = "2026-05-19T10:09:40.727Z" },
+    { url = "https://files.pythonhosted.org/packages/73/38/505941b2b092fd5bbbd60a52a880db1173f1690ae6751bed3af1c9ddcb4e/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:631f13a3d04e97d4e083993b10f4b99530e3a10d953e2eb5e196b7dc7f812ce0", size = 303769, upload-time = "2026-05-19T10:09:42.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/95/a06692b29e77473f286e1ec1f426d3ca44d7b5843be8ad21d7a5f3fcdcc0/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45", size = 305128, upload-time = "2026-05-19T10:09:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/7270d7ad41d6061a25b950c6bf91d638bd9aacb113200a8c8d57a055fd67/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c", size = 340459, upload-time = "2026-05-19T10:09:45.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469, upload-time = "2026-05-19T10:09:46.864Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "lakefs"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lakefs-sdk" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/60/5cdf074905ac0bb1fe11570ad56e94f22df651d02b67ab267fbdf46bb561/lakefs-0.16.0.tar.gz", hash = "sha256:f17afa5f8d99a622e7d8088a57c74262ae058befc6a4eba7e4b6cc9704f84748", size = 34340, upload-time = "2026-04-10T16:37:22.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/af/15e3bb8b125795c008ff57fa2592130f5f25a0521726e44f3902f8903a60/lakefs-0.16.0-py3-none-any.whl", hash = "sha256:a513bc8b5a64d31b1ed75ce11aee803de84c1e9c11207a042acd874012799b0b", size = 39324, upload-time = "2026-04-10T16:37:21.451Z" },
+]
+
+[[package]]
+name = "lakefs-e2b-common"
+version = "0.1.0"
+source = { editable = "shared" }
+dependencies = [
+    { name = "lakefs" },
+    { name = "python-dotenv" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "lakefs" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+]
+
+[[package]]
+name = "lakefs-e2b-poc"
+version = "0.1.0"
+source = { editable = "usecases/01-sdk-orchestrator" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "e2b" },
+    { name = "lakefs" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "pytest" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "boto3", specifier = ">=1.28.0" },
+    { name = "botocore", specifier = ">=1.31.0" },
+    { name = "e2b", specifier = ">=1.0.0" },
+    { name = "lakefs" },
+    { name = "pandas", specifier = ">=2.0.0" },
+    { name = "pyarrow", specifier = ">=12.0.0" },
+    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "rich", specifier = ">=13.0.0" },
+]
+
+[[package]]
+name = "lakefs-sdk"
+version = "1.81.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aenum" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/71/f1f93b220da1f1ee7d752e16ae5867b061eed0691ddc0f894b1067d73dc9/lakefs_sdk-1.81.1.tar.gz", hash = "sha256:f63b167ce39a09fe5be2784b923877ac1c12445861d87eae5c2689536e711f07", size = 128412, upload-time = "2026-05-21T16:24:24.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/fb/271489ade0829a65d1c6b39ac9db3c087f9342eb67252d510df0ebd58a8e/lakefs_sdk-1.81.1-py3-none-any.whl", hash = "sha256:74a05708b6812e35600ee5f9baf731238fb356fdbdf571e69130a145691aaa31", size = 225288, upload-time = "2026-05-21T16:24:22.799Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mount-receipts"
+version = "0.1.0"
+source = { editable = "usecases/03-mount-receipts" }
+dependencies = [
+    { name = "e2b" },
+    { name = "lakefs" },
+    { name = "lakefs-e2b-common" },
+    { name = "openai" },
+    { name = "pillow" },
+    { name = "pymupdf" },
+    { name = "pytest" },
+    { name = "python-dateutil" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "e2b", specifier = ">=1.0.0" },
+    { name = "lakefs" },
+    { name = "lakefs-e2b-common", editable = "shared" },
+    { name = "openai", specifier = ">=1.0.0" },
+    { name = "pillow", specifier = ">=10.0.0" },
+    { name = "pymupdf", specifier = ">=1.24.0" },
+    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "python-dateutil", specifier = ">=2.8.0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "rich", specifier = ">=13.0.0" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0d/f5957185c0ee2f3e12f78715aa9e3b353fd83633316c8532b38faa37e3f6/numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d", size = 14964111, upload-time = "2026-05-18T23:33:17.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/40/40a40ee0ddf7ceb782c49af278894b686e586d65d8c1889c8b5da01a3d7d/numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8", size = 5469159, upload-time = "2026-05-18T23:33:20.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/f9a8046535cb21deae82f8d03de9617e08882d274fad2539630761888228/numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538", size = 6798936, upload-time = "2026-05-18T23:33:22.987Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a8/6fa8c1a345a8c85dbb21932c447bee07c30a2c2a3f31e369c0a84b300147/numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47", size = 15966692, upload-time = "2026-05-18T23:33:26.62Z" },
+    { url = "https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93", size = 16918164, upload-time = "2026-05-18T23:33:29.955Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/80/3615be3313f7e7696609bc194b9f0101da809df79e859bdb84e0cd043f46/numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8", size = 17322877, upload-time = "2026-05-18T23:33:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/a691e0fe2675e370d0e08ff905adc49a1c8830e8cae03efe4477e92cd55d/numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6", size = 18651487, upload-time = "2026-05-18T23:33:38.217Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a7/9bc1cd626d7bf6869bfedf27b91b6ab5dd607758bf8e959d6fa80c6a59cb/numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8", size = 6233945, upload-time = "2026-05-18T23:33:41.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/7fc6239c12bce7e931463251cca4426c465e1876ba3cc785402ef4dd8f4e/numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147", size = 12608406, upload-time = "2026-05-18T23:33:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/140f85a466595a16382996a1bf06b2b54bcd597488921b0c9daaeeda72af/numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577", size = 10479528, upload-time = "2026-05-18T23:33:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+    { url = "https://files.pythonhosted.org/packages/de/12/b422cc84439adc0d00de605bf4a308890ae5c26f2c71fbd73e5d08fbb0dd/numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662", size = 16847511, upload-time = "2026-05-18T23:36:50.673Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/f481bef68011740f8849418d82db07230e825013f31f4eef5ba5b805316a/numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7", size = 14889064, upload-time = "2026-05-18T23:36:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/57/42ed575c10ced8af951d426bc4e1f8aff16fd851db33f067036215a7f860/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f", size = 5394157, upload-time = "2026-05-18T23:36:57.194Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/f66cc724fcc36c1e364c67f51ae9146090b8b584f27d58b97fdae3edd737/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c", size = 6708728, upload-time = "2026-05-18T23:36:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/a6/5815fe2e2aca74b36c650d1bd43b69827cee568073d0d2d9b6fc5aaac80c/openai-2.41.0.tar.gz", hash = "sha256:db5c362acd6604b84f076abbefa66826ea4b46ecba2954ed866e6a149a1352c0", size = 783525, upload-time = "2026-06-03T22:39:40.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/51/d82bb424e8aa372190c5233253a2ceb399a778747d18b42cff487411e663/openai-2.41.0-py3-none-any.whl", hash = "sha256:20cc7952e8501c7e5773dd2ef7be437bae9cb549044902e1041a83a54516e375", size = 1353378, upload-time = "2026-06-03T22:39:38.964Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/16/b5c76b838fd9bf6ce84d3a53346b8874ec05c5f0040d75ef2c320100cd2a/pandas-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:455f6f8139d4282188f526868dbc3c828470e88a3d9d59a891bd46a455f21b98", size = 10338495, upload-time = "2026-05-11T18:52:11.558Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/b0/a4ffc4ae74d2d822200dcc46898987d8eb6032d1e2b219cae39da6f5cbcc/pandas-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4e15135e2ee5df1063313e2425ceef8ac0f4ae775893815b0923651b806a5639", size = 9938250, upload-time = "2026-05-11T18:52:17.005Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b2/3323601a52caee42c019e370090ca4544b241437240ca04f786cce82b0cf/pandas-3.0.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:05f1f1752b8533ea03f7f39a9c15b1a058d067bb48f4748948e7a8691e0510f2", size = 10770558, upload-time = "2026-05-11T18:52:19.865Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f1/bbecd2f867b97abebe0f9b53d750f862251b40337e061b36676ded3d920f/pandas-3.0.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a1e45c80cceb3b4a21bc5939d52e8cbd8d9b7305309219d59e9754d9ce09e27", size = 11274611, upload-time = "2026-05-11T18:52:22.622Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/4f/eafabf2d5fae5adf143b4d18d3706c5efdc368a7c4eb1ee8a3eddabbd0f6/pandas-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:14da8316da4d0c5a77618425996bfb1248ca87fc2c1486e6fde4652bd18b5824", size = 11784670, upload-time = "2026-05-11T18:52:25.4Z" },
+    { url = "https://files.pythonhosted.org/packages/49/44/1eb20389301b57b19cc099a1c2f662501f72f08a65f912d05822613c1532/pandas-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a55066a0505dae0ba2b50a46637db34b46f9094c65c5d4800794ef6335010938", size = 12353708, upload-time = "2026-05-11T18:52:28.139Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/c321f13b5ba1819fc8dca456c7fce578da2dcfecff1abbf0eaddf8406c0f/pandas-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:6674ab18ad8c57802867264b00e15e7bb904700cdd9046e3b2fa1fce237439ea", size = 9907609, upload-time = "2026-05-11T18:52:30.982Z" },
+    { url = "https://files.pythonhosted.org/packages/53/85/1b7f563ebc6357c27233a02a96b589bcce1fa9c6eb89fb4f0e56421d277e/pandas-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:5cc09a68b3120e0f54870dede8287a7bb1fa463907e4fcec1ea77cab6179bf7a", size = 9165596, upload-time = "2026-05-11T18:52:33.334Z" },
+    { url = "https://files.pythonhosted.org/packages/24/f1/392f8c5bfc16f66a0d2d41561c01627c228fe7ed2a0d056ef11315042570/pandas-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fed2ff7fd9779120e388e285fc029bd5cf9490cdd2e4166a9ee22c0e49a9ab09", size = 10357846, upload-time = "2026-05-11T18:52:36.143Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3d/b16412745651e855f357e5e66930248688378853a6e2698a214e331fba1f/pandas-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b168fc218fd80a6cbdbdbc1a97ddc7889ed057d7eb45f50d866ceab5f39904c4", size = 9899550, upload-time = "2026-05-11T18:52:38.976Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a8/fa2535168fffcedf67f4f6de28d2dd903a747ca7c8ea6989451aaeb3a92f/pandas-3.0.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0383c72c75cdcca61a9e116e611143902dbfd08bff356829c2f6d1cf40a9ca8c", size = 10412965, upload-time = "2026-05-11T18:52:41.915Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b6/09b01cdbc15224e2850365192d17b7bdebb8bdbd8780ed221fcdf0d9a515/pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6dc0b3fd2169c9157deed50b4d519553a3655c8c6a96027136d654592be973a9", size = 10894600, upload-time = "2026-05-11T18:52:45.02Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/2eb28f2fccb4ced4a2c79ab2a5dee9ade1ebf44922ebad6fea158c9f95d4/pandas-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7e65d5407dc0b394f509699650e4a2ec01c0514f21850f453fa60f3be79a5dbf", size = 11422824, upload-time = "2026-05-11T18:52:48.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/45/830bb57f533a4604b355e07edcb8ea18cf88b5f94e5fca92f27052d7c597/pandas-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8894dc474d648fe7b6ff0ca9b0bd73950d19952bc1a6534540762c5d79d305c", size = 11950889, upload-time = "2026-05-11T18:52:50.905Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c5/fc1b368f303087d20e8c9bf3d6ceb186263cfac0ade735cd938538bea839/pandas-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c7be265b62cef88e253a941e4698604973736dcfe242fdb5198f0f7bc473cdcc", size = 9755463, upload-time = "2026-05-11T18:52:53.386Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bd/fda8f9705b1b09c6ebe14bfc0fa0e4ec8584d54ea673628f157ff55131af/pandas-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:557409bc4178e70ee8d9ddb494798e51ebf6ea59330f6be22c51bab2a7db6c49", size = 9066158, upload-time = "2026-05-11T18:52:56.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa", size = 10331071, upload-time = "2026-05-11T18:52:58.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7", size = 9875690, upload-time = "2026-05-11T18:53:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8", size = 10381634, upload-time = "2026-05-11T18:53:04.393Z" },
+    { url = "https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a", size = 10891243, upload-time = "2026-05-11T18:53:07.643Z" },
+    { url = "https://files.pythonhosted.org/packages/25/93/77d108e8af7222b4a503ebde0e30215b1c2e4f8e53a526431890f22d5586/pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb", size = 11388659, upload-time = "2026-05-11T18:53:10.634Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/bd/eff5b4399f332ac386c853f6cd2bd3fa2ca0061b9f36ecd9c4d7c4265649/pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2", size = 11942880, upload-time = "2026-05-11T18:53:13.536Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/20/559ace4200982c3887d0b86bfd0d856a2143ef8ddab63cc07934951a964c/pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44", size = 9757091, upload-time = "2026-05-11T18:53:16.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/66/69055a09fe200f29f922a3eeec4804611900b95f52d932ece3393c3c0c19/pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e", size = 9057282, upload-time = "2026-05-11T18:53:18.768Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0e/efe801b0e6811e8e650cd21b7f2608e30f08a7067e2bf6e8752b0d56ee3c/pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d", size = 10767016, upload-time = "2026-05-11T18:53:21.227Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/dc/eb55135a1d5f0f0519f28da1f609a206d2cad1f9c35c32d51e38dd7261ae/pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066", size = 10420210, upload-time = "2026-05-11T18:53:23.982Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/b1d5d955ce33ffecb407465a60bc32769d74fcf68224b7ae67ae11d4dea4/pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd", size = 10336126, upload-time = "2026-05-11T18:53:26.731Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/76/a01261711ab60a22d71b862f0de20e4c504bf80457270ad8cb42110f6abc/pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085", size = 10728051, upload-time = "2026-05-11T18:53:29.125Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796, upload-time = "2026-05-11T18:53:32.056Z" },
+    { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741, upload-time = "2026-05-11T18:53:34.985Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958, upload-time = "2026-05-11T18:53:37.857Z" },
+    { url = "https://files.pythonhosted.org/packages/86/54/effdcc3c0ff7a08037889200e148ebe94c16c4f653be078c7b3675955df1/pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac", size = 10336065, upload-time = "2026-05-11T18:53:41.099Z" },
+    { url = "https://files.pythonhosted.org/packages/68/10/bf2d6738d72748b961a3751ab89522d58c54efc36a8e1a12161216cd45cf/pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f", size = 9926101, upload-time = "2026-05-11T18:53:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e9/e35cf11c8a136e757b956f5f0efdcaa50aecde85ea055f1898dfc68262f3/pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb", size = 10457553, upload-time = "2026-05-11T18:53:46.394Z" },
+    { url = "https://files.pythonhosted.org/packages/58/3b/1cdec6772bdbaf7b25dab360c59f03cadf05492dd724c6540af905389b07/pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a", size = 10914065, upload-time = "2026-05-11T18:53:49.134Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/1ef644445fcd72e3627bceec77e3560636f87ddce4ed841afe76b83b5bf9/pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360", size = 11459188, upload-time = "2026-05-11T18:53:52.527Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/49/4d8d4f42cbc9c4adc7a1870f269c02cbd6cd40d059622c06fb298addcbad/pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76", size = 11982966, upload-time = "2026-05-11T18:53:55.043Z" },
+    { url = "https://files.pythonhosted.org/packages/38/55/792619469bab9882d8bbd5865d45a72f6478762d04a9af4bf0d08c503e95/pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5", size = 9876755, upload-time = "2026-05-11T18:53:58.067Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/af/33c469653b0ba03b50c3a98192d4c07f0c75c66b263ceb097fce0ee97d31/pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977", size = 9198658, upload-time = "2026-05-11T18:54:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/fa/b8c257bd76b8bd060c3a9151c1fca05e9b9c5e3af5d0f549c0356f6d143d/pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04", size = 10787242, upload-time = "2026-05-11T18:54:03.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/eb/f19206ffb0bf1919002969aa448b4702c6594845156a6f8050674855aac3/pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6", size = 10436369, upload-time = "2026-05-11T18:54:06.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/24/c7c39fb4fe22b71a0c2d78bf0c585c600092d85f94f086d2b3b2f6ca27e2/pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c", size = 10358306, upload-time = "2026-05-11T18:54:09.085Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ec/dd2a9eb7fa1204df88c0864164e35b228ac581062ac612ba0a67fd812e4c/pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028", size = 10758394, upload-time = "2026-05-11T18:54:11.956Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6e/00c61ea8e85b4f6d8d35e11852a1a4998fc7fafc91c6a602d1cc9c972d64/pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d", size = 11375717, upload-time = "2026-05-11T18:54:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897, upload-time = "2026-05-11T18:54:17.146Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855, upload-time = "2026-05-11T18:54:19.72Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464, upload-time = "2026-05-11T18:54:22.754Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/e1/748f5663efe6edcfc4e74b2b93edfb9b8b99b67f21a854c3ae416500a2d9/pillow-12.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:8be29e59487a79f173507c30ddf57e733a357f67881430449bb32614075a40ab", size = 5354347, upload-time = "2026-04-01T14:42:44.255Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a1/d5ff69e747374c33a3b53b9f98cca7889fce1fd03d79cdc4e1bccc6c5a87/pillow-12.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71cde9a1e1551df7d34a25462fc60325e8a11a82cc2e2f54578e5e9a1e153d65", size = 4695873, upload-time = "2026-04-01T14:42:46.452Z" },
+    { url = "https://files.pythonhosted.org/packages/df/21/e3fbdf54408a973c7f7f89a23b2cb97a7ef30c61ab4142af31eee6aebc88/pillow-12.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f490f9368b6fc026f021db16d7ec2fbf7d89e2edb42e8ec09d2c60505f5729c7", size = 6280168, upload-time = "2026-04-01T14:42:49.228Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f1/00b7278c7dd52b17ad4329153748f87b6756ec195ff786c2bdf12518337d/pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8bd7903a5f2a4545f6fd5935c90058b89d30045568985a71c79f5fd6edf9b91e", size = 8088188, upload-time = "2026-04-01T14:42:51.735Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cf/220a5994ef1b10e70e85748b75649d77d506499352be135a4989c957b701/pillow-12.2.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3997232e10d2920a68d25191392e3a4487d8183039e1c74c2297f00ed1c50705", size = 6394401, upload-time = "2026-04-01T14:42:54.343Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/bd/e51a61b1054f09437acfbc2ff9106c30d1eb76bc1453d428399946781253/pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e74473c875d78b8e9d5da2a70f7099549f9eb37ded4e2f6a463e60125bccd176", size = 7079655, upload-time = "2026-04-01T14:42:56.954Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3d/45132c57d5fb4b5744567c3817026480ac7fc3ce5d4c47902bc0e7f6f853/pillow-12.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:56a3f9c60a13133a98ecff6197af34d7824de9b7b38c3654861a725c970c197b", size = 6503105, upload-time = "2026-04-01T14:42:59.847Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/2e/9df2fc1e82097b1df3dce58dc43286aa01068e918c07574711fcc53e6fb4/pillow-12.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90e6f81de50ad6b534cab6e5aef77ff6e37722b2f5d908686f4a5c9eba17a909", size = 7203402, upload-time = "2026-04-01T14:43:02.664Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2e/2941e42858ebb67e50ae741473de81c2984e6eff7b397017623c676e2e8d/pillow-12.2.0-cp311-cp311-win32.whl", hash = "sha256:8c984051042858021a54926eb597d6ee3012393ce9c181814115df4c60b9a808", size = 6378149, upload-time = "2026-04-01T14:43:05.274Z" },
+    { url = "https://files.pythonhosted.org/packages/69/42/836b6f3cd7f3e5fa10a1f1a5420447c17966044c8fbf589cc0452d5502db/pillow-12.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:6e6b2a0c538fc200b38ff9eb6628228b77908c319a005815f2dde585a0664b60", size = 7082626, upload-time = "2026-04-01T14:43:08.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/88/549194b5d6f1f494b485e493edc6693c0a16f4ada488e5bd974ed1f42fad/pillow-12.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:9a8a34cc89c67a65ea7437ce257cea81a9dad65b29805f3ecee8c8fe8ff25ffe", size = 2463531, upload-time = "2026-04-01T14:43:10.743Z" },
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b7/2437044fb910f499610356d1352e3423753c98e34f915252aafecc64889f/pillow-12.2.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538bd5e05efec03ae613fd89c4ce0368ecd2ba239cc25b9f9be7ed426b0af1f", size = 5273969, upload-time = "2026-04-01T14:45:55.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f4/8316e31de11b780f4ac08ef3654a75555e624a98db1056ecb2122d008d5a/pillow-12.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:394167b21da716608eac917c60aa9b969421b5dcbbe02ae7f013e7b85811c69d", size = 4659674, upload-time = "2026-04-01T14:45:58.093Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/37/664fca7201f8bb2aa1d20e2c3d5564a62e6ae5111741966c8319ca802361/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5d04bfa02cc2d23b497d1e90a0f927070043f6cbf303e738300532379a4b4e0f", size = 5288479, upload-time = "2026-04-01T14:46:01.141Z" },
+    { url = "https://files.pythonhosted.org/packages/49/62/5b0ed78fce87346be7a5cfcfaaad91f6a1f98c26f86bdbafa2066c647ef6/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0c838a5125cee37e68edec915651521191cef1e6aa336b855f495766e77a366e", size = 7032230, upload-time = "2026-04-01T14:46:03.874Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404, upload-time = "2026-04-01T14:46:06.33Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946, upload-time = "2026-04-01T14:46:11.734Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/fd/5b1491d9e4b586d621c54f4c36b888714164b6875f8d6afa3f9072906a51/protobuf-7.35.0.tar.gz", hash = "sha256:a2efd84605f41e559f1881b0912b44099d0a2ac9bf46b3474823f10fb393b0e6", size = 458677, upload-time = "2026-05-19T23:02:29.197Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ee/93d06e358a4aa32280b00e722d3ea0a1f25fc3cc5778d80581c9cca2c10e/protobuf-7.35.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:66be6c513931c794fa92c080ffee41671390da3d79da219cf9c0c0907f035dda", size = 433225, upload-time = "2026-05-19T23:02:19.884Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/39/1c76c2da93f3c507e958e0aecee2391cc44d4625de6c728bbc555195b5a8/protobuf-7.35.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:fcbe42a4ac09d3ec9c987ddfcd956afd0b15f1ff613bd8371bde9405ffd5c8e5", size = 328847, upload-time = "2026-05-19T23:02:22.3Z" },
+    { url = "https://files.pythonhosted.org/packages/91/1a/39f7ce90a238c1a987a4d81ec26379e02ca0aff367de68e4a1fa474215b9/protobuf-7.35.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:4cbf5cc286130e06a6c9bbefac442431173906dfcc979712183d4adcc01b37ee", size = 344030, upload-time = "2026-05-19T23:02:23.591Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5b/6baf9008817964454055ff3fe65f1de0b5f1e26c80c82f7fb108b7cd4ea3/protobuf-7.35.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:6c0f98f10c8a05ea30f8993dfef2de093d27b490fdae78bb60c8343795d55011", size = 327130, upload-time = "2026-05-19T23:02:24.637Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e5/e46adb0badc388bfb84877a5f9f026aff63f60e611016cf64dbe77e05446/protobuf-7.35.0-cp310-abi3-win32.whl", hash = "sha256:4c4617b83ade0e279d1d2bfe04025a1adb87f9ed657de038620dc0ff959357f6", size = 428946, upload-time = "2026-05-19T23:02:25.741Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ab/547fbd9e16d879dd13c167478f8ae0a83a428008ca07a5e06acdc23ad473/protobuf-7.35.0-cp310-abi3-win_amd64.whl", hash = "sha256:f05bcadf9a2a6b8dda047007075135fb7d08c73d9177aabc067e1be46881a201", size = 439996, upload-time = "2026-05-19T23:02:26.808Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ef/50433d346c56657a70d27f156c7b349ac59a068b01de4eb796e747eecc43/protobuf-7.35.0-py3-none-any.whl", hash = "sha256:c13f325cf242bad135c350629eeb5d54b24228eb472fb3e2e9ebbd4c5dc20ca0", size = 171659, upload-time = "2026-05-19T23:02:27.842Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/c9/a47ab7ece0d86cbe6678418a0fbd1ac4bb493b9184a3891dfa0e7f287ae0/pyarrow-24.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b0e131f880cda8d04e076cee175a46fc0e8bc8b65c99c6c09dff6669335fde74", size = 35068898, upload-time = "2026-04-21T10:46:36.599Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/bc/8db86617a9a58008acf8913d6fed68ea2a46acb6de928db28d724c891a68/pyarrow-24.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:1b2fe7f9a5566401a0ef2571f197eb92358925c1f0c8dba305d6e43ea0871bb3", size = 36679915, upload-time = "2026-04-21T10:46:42.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8e/fb178720400ef69db251eb4a9c3ccf4af269bc1feb5055529b8fc87170d1/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0b3537c00fb8d384f15ac1e79b6eb6db04a16514c8c1d22e59a9b95c8ba42868", size = 45697931, upload-time = "2026-04-21T10:46:48.403Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/27/99c42abe8e21b44f4917f62631f3aa31404882a2c41d8a4cd5c110e13d52/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:14e31a3c9e35f1ab6356c6378f6f72830e6d2d5f1791df3774a7b097d18a6a1e", size = 48837449, upload-time = "2026-04-21T10:46:55.329Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b6/333749e2666e9032891125bf9c691146e92901bece62030ac1430e2e7c88/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b7d9a514e73bc42711e6a35aaccf3587c520024fe0a25d830a1a8a27c15f4f57", size = 49395949, upload-time = "2026-04-21T10:47:01.869Z" },
+    { url = "https://files.pythonhosted.org/packages/17/25/c5201706a2dd374e8ba6ee3fd7a8c89fb7ffc16eed5217a91fd2bd7f7626/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b196eb3f931862af3fa84c2a253514d859c08e0d8fe020e07be12e75a5a9780c", size = 51912986, upload-time = "2026-04-21T10:47:09.872Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d2/4d1bbba65320b21a49678d6fbdc6ff7c649251359fdcfc03568c4136231d/pyarrow-24.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:35405aecb474e683fb36af650618fd5340ee5471fc65a21b36076a18bbc6c981", size = 27255371, upload-time = "2026-04-21T10:47:15.943Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660, upload-time = "2026-04-21T10:48:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pymupdf"
+version = "1.27.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/32/708bedc9dde7b328d45abbc076091769d44f2f24ad151ad92d56a6ec142b/pymupdf-1.27.2.3.tar.gz", hash = "sha256:7a92faa25129e8bbec5e50eeb9214f187665428c31b05c4ef6e36c58c0b1c6d2", size = 85759618, upload-time = "2026-04-24T14:13:14.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/09/ddbdfa7ee91fbabd6f63d7d744884cbdfe3e7ff9b8604749fb38bddf5c5d/pymupdf-1.27.2.3-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc1bc3cae6e9e150b0dbb0a9221bdfd411d65f0db2fe359eaa22467d7cc2a05f", size = 24002636, upload-time = "2026-04-24T14:09:17.459Z" },
+    { url = "https://files.pythonhosted.org/packages/01/89/3f8edd6c4f50ca370e2a2f2a3011face36f3760728ffe76dffec91c0fca0/pymupdf-1.27.2.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:660d93cb6da5bbddf11d3982ae27745dd3a9902d9f24cdb69adab83962294b5a", size = 23278238, upload-time = "2026-04-24T14:09:32.882Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/26/b7e5a70eb83bd189f8b5df87ec442746b992f2f632662839b288170d357d/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1dd460a3ae4597a755f00a3bd9771f5ebf1531dc111f6a36bf05dd00a6b84425", size = 24333923, upload-time = "2026-04-24T14:09:47.341Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a0/aa1ee2240f29481a04a827c313333b4ecd8a14d6ac3e15d3f41a30574781/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:857842b4888827bd6155a1131341b2822a7ebe9a8c15a975fd7d490d7a64a30c", size = 24963198, upload-time = "2026-04-24T14:10:07.408Z" },
+    { url = "https://files.pythonhosted.org/packages/69/49/4f742451f980840829fc00ba158bebb25d389c846d8f4f8c65936ee55de8/pymupdf-1.27.2.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:580983849c64a08d08344ca3d1580e87c01f046a8392421797bc850efd72a5b6", size = 25184609, upload-time = "2026-04-24T14:10:22.911Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/3f/3853d6608f394faf6eec2bd4e8ea9f6a00beea329b071abdb29f4164cc3d/pymupdf-1.27.2.3-cp310-abi3-win32.whl", hash = "sha256:a5c1088a87189891a4946ab314a14b7934ac4c5b6077f7e74ebee956f8906d0e", size = 18019286, upload-time = "2026-04-24T14:10:34.239Z" },
+    { url = "https://files.pythonhosted.org/packages/44/47/5fb10fe73f96b31253a41647c362ea9e0380920bddf16028414a051247fc/pymupdf-1.27.2.3-cp310-abi3-win_amd64.whl", hash = "sha256:d20f68ef15195e073071dbc4ae7455257c7889af7584e39df490c0a92728526e", size = 19249102, upload-time = "2026-04-24T14:10:46.72Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a4/b9e91aac82293f9c954654c85581ee8212b5b05efadc534b581141241e6f/pymupdf-1.27.2.3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:77691604c5d1d0233827139bbcdea61fd57879c84712b8e49b1f45520f7ab9c2", size = 25000393, upload-time = "2026-04-24T14:11:01.669Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.68.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/1e/a5e2602851e2a8c49372e3ed4d8437fa43c996941899af7aea6e30173a3d/tqdm-4.68.0.tar.gz", hash = "sha256:c627124266fe7904cabb70e88a940d75a06b889a0b11680307a67c18ce094f19", size = 170209, upload-time = "2026-06-05T13:17:20.095Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/51/ab57af723f38a041c5027040fc6fa93a9a066ca7294fc380c1c0810813b2/tqdm-4.68.0-py3-none-any.whl", hash = "sha256:b79a3ae57db4c870a55352e43abb33b329557cd75b1483028909286ff22a2c03", size = 78247, upload-time = "2026-06-05T13:17:18.272Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
+]


### PR DESCRIPTION
## What

Adds a new standalone example under `01_standalone_examples/e2b/` demonstrating the **Agentic Data PR** pattern: an AI agent runs in an isolated **E2B** sandbox and versions its work in **lakeFS** — each run on its own branch, committed every iteration, and gated by a pre-merge Action before reaching `main`.

Three self-contained use cases:

| # | Use case | Pattern | Data path |
|---|----------|---------|-----------|
| 1 | `01-sdk-orchestrator` | Orchestrated agent job: isolated compute + isolated data branch | lakeFS Python SDK |
| 2 | `02-three-phase-repair` | Iterative LLM data repair through three progressive validation phases | lakeFS Python SDK |
| 3 | `03-mount-receipts` | Multimodal receipts → ledger; agent works on a mounted lakeFS branch | lakeFS Mount (`everest`) |

## Notes for reviewers

- **Layout:** kept as a **uv workspace** (one `uv sync` at the `e2b/` root, shared `lakefs_e2b_common` package) rather than the notebook style of neighboring examples — it's the tested, working setup.
- **Prerequisites / signup links:** E2B ([e2b.dev](https://e2b.dev)) and lakeFS Cloud ([lakefs.cloud](https://lakefs.cloud/)) are linked in the root and per-use-case READMEs.
- **Secrets & binaries:** all real `.env` files, the `everest` Enterprise Mount binary, and tarballs are gitignored and intentionally **not** shipped. Use case 3 documents how to obtain `everest` (download / contact lakeFS), matching the existing `lakefs-mount-demo`.

## Testing

All three use cases were run end-to-end against live lakeFS Cloud + E2B + OpenAI and passed; `uv run pytest` is green (33 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)