### PR TITLE
Use case 3: agent-generated validator + independent lakeFS gate

### DIFF
--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/.env.example
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/.env.example
@@ -21,3 +21,6 @@ OPENAI_MODEL=gpt-4o
 # === Run control ===
 # Optional: pin "today" for reproducible date checks (e.g. the future-dated reject). Empty = real today.
 DEMO_TODAY=
+# Optional: set to 1 to corrupt one accepted row after validation, so the lakeFS pre-merge
+# gate independently catches it and BLOCKS the merge (demonstrates the gate). Empty = off.
+DEMO_TAMPER=

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/README.md
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/README.md
@@ -42,31 +42,48 @@ agent works in **three progressive phases**, each committed to its branch:
 |-------|--------------|------------------------------------|
 | **1 — Triage (structural)** | hash-dedupe, drop corrupt/unreadable & unsupported files, drop non-receipts (vision `is_receipt`) | a corrupt file, an exact duplicate, a beach photo, a `.txt` note |
 | **2 — Extract (multimodal)** | gpt-4o reads each kept file → `{vendor, date, invoice_no, currency, line_items, total}` cached as sidecars → `ledger_draft` (multi-page PDFs are page-stacked so a total on page 2 is read) | (the low-contrast receipt still extracts) |
-| **3 — Validate (business rules)** | the agent is handed the rules + extracted receipts and **writes its own Python validator at runtime**, which is then executed in the sandbox: `total == sum(items)`, date sane & not future, currency = USD, unique invoice no, total ≤ \$500 cap | math mismatch, future-dated, EUR, duplicate invoice #, over-cap |
+| **3 — Validate (business rules)** | the agent **writes its own Python validator at runtime** for the per-receipt rules and runs it in the sandbox: `total == sum(items)`, date sane & not future, currency = USD, total ≤ \$500 cap. The host then applies the cross-row **unique invoice no** rule deterministically. | math mismatch, future-dated, EUR, over-cap, duplicate invoice # |
 
 A clean run produces **4 accepted / 5 rejected / 4 dropped**, written to `ledger.csv` and
 `rejects.csv`.
 
 ### Why the validator is generated at runtime — and why lakeFS still gates
 
-The validation logic in Phase 3 is **not shipped in the repo** — the agent writes it on the
-fly from a rule *specification* (`mount_receipts/validation.py: RULES_SPEC`) and executes it
-inside the sandbox (`mount_receipts/codegen.py`). That is the point of running it in E2B:
-**you are executing code you have never seen, generated at runtime, and the sandbox contains
-whatever it does** — a self-repair loop re-prompts the model if its script crashes or
+The per-receipt validation logic in Phase 3 is **not shipped in the repo** — the agent writes
+it on the fly from a rule *specification* (`mount_receipts/validation.py: RULES_SPEC`) and
+executes it inside the sandbox (`mount_receipts/codegen.py`). That is the point of running it
+in E2B: **you are executing code you have never seen, generated at runtime, and the sandbox
+contains whatever it does** — a self-repair loop re-prompts the model if its script crashes or
 violates the I/O contract, with a reference implementation as a last-resort fallback so the
-demo always completes. The exact generated script, its input, and its output are committed
-to the branch under `validation/` so the run is fully auditable.
+demo always completes. The exact generated script, its input, and its output are committed to
+the branch under `validation/` so the run is fully auditable.
+
+> **Why one rule stays deterministic.** The model judges each receipt *on its own*. The only
+> cross-record rule — invoice-number uniqueness, which needs a whole-batch pass — is the one
+> LLMs reliably get wrong, so the host owns it (`apply_cross_row_uniqueness`). The generated
+> code still does the substantive per-receipt work; this just keeps the happy path reliable.
 
 Because that validator is LLM-written and therefore *untrusted*, lakeFS does **not** take its
-word for it. The **pre-merge Action** (`lakefs_actions/validate_ledger.yaml`) re-reads the
-committed `ledger.csv` and **independently re-derives** pass/fail — re-checking currency, the
-\$500 cap, ISO date/year, invoice-number uniqueness, and that the accepted-row count matches
-the agent's self-reported result. It does not trust `validation/latest_result.json`'s status
-field alone. So a half-processed, invalid, or self-certified ledger physically cannot be
-promoted to `main`, regardless of what code the agent ran or who triggers the merge. **E2B is
-the compute trust boundary (run unknown code safely); lakeFS is the data trust boundary
-(unknown data can't reach `main`).**
+word for it. The **pre-merge Action** (`lakefs_actions/validate_ledger.yaml`) reads the typed
+`validation/gate_input.json` the agent committed and **independently re-derives** accept/reject
+for **every** drafted row — re-checking `total == sum(items)`, the \$500 cap, currency, ISO
+date/year, **and** invoice-number uniqueness across the whole batch — then blocks the merge if
+the validator accepted any row that violates policy (and cross-checks the accepted-row count).
+It does not trust `validation/latest_result.json`'s status field. So a half-processed,
+invalid, or self-certified ledger physically cannot be promoted to `main`, regardless of what
+code the agent ran or who triggers the merge. **E2B is the compute trust boundary (run unknown
+code safely); lakeFS is the data trust boundary (unknown data can't reach `main`).**
+
+### See the gate fire
+
+In the happy path the gate re-validates and the clean ledger merges. To watch it *block* a bad
+ledger, set `DEMO_TAMPER=1`: after validation passes, one accepted row is corrupted to a
+non-USD currency (the agent still self-reports "passed"), and the lakeFS gate independently
+rejects the merge — nothing reaches `main`.
+
+```bash
+DEMO_TAMPER=1 uv run python -m mount_receipts.main   # gate blocks the merge
+```
 
 ---
 
@@ -99,9 +116,9 @@ the compute trust boundary (run unknown code safely); lakeFS is the data trust b
                  ┌──────────────────────┐
                  │      lakeFS          │
                  │  • agent branch      │
-                 │  • pre-merge gate    │  ← re-validates ledger.csv
-                 │                      │    independently (doesn't
-                 │                      │    trust the agent's status)
+                 │  • pre-merge gate    │  ← re-derives every row's
+                 │                      │    verdict from gate_input.json
+                 │                      │    (doesn't trust the status)
                  └──────────┬───────────┘
                             │ merge only when the gate passes
                             ▼

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/README.md
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/README.md
@@ -42,12 +42,31 @@ agent works in **three progressive phases**, each committed to its branch:
 |-------|--------------|------------------------------------|
 | **1 — Triage (structural)** | hash-dedupe, drop corrupt/unreadable & unsupported files, drop non-receipts (vision `is_receipt`) | a corrupt file, an exact duplicate, a beach photo, a `.txt` note |
 | **2 — Extract (multimodal)** | gpt-4o reads each kept file → `{vendor, date, invoice_no, currency, line_items, total}` cached as sidecars → `ledger_draft` (multi-page PDFs are page-stacked so a total on page 2 is read) | (the low-contrast receipt still extracts) |
-| **3 — Validate (business rules)** | `total == sum(items)`, date sane & not future, currency = USD, unique invoice no, total ≤ \$500 cap | math mismatch, future-dated, EUR, duplicate invoice #, over-cap |
+| **3 — Validate (business rules)** | the agent is handed the rules + extracted receipts and **writes its own Python validator at runtime**, which is then executed in the sandbox: `total == sum(items)`, date sane & not future, currency = USD, unique invoice no, total ≤ \$500 cap | math mismatch, future-dated, EUR, duplicate invoice #, over-cap |
 
 A clean run produces **4 accepted / 5 rejected / 4 dropped**, written to `ledger.csv` and
-`rejects.csv`. A lakeFS **pre-merge Action** (`lakefs_actions/validate_ledger.yaml`) gates
-`main` on `validation/latest_result.json` — so a half-processed or invalid ledger physically
-cannot be promoted, regardless of who triggers the merge.
+`rejects.csv`.
+
+### Why the validator is generated at runtime — and why lakeFS still gates
+
+The validation logic in Phase 3 is **not shipped in the repo** — the agent writes it on the
+fly from a rule *specification* (`mount_receipts/validation.py: RULES_SPEC`) and executes it
+inside the sandbox (`mount_receipts/codegen.py`). That is the point of running it in E2B:
+**you are executing code you have never seen, generated at runtime, and the sandbox contains
+whatever it does** — a self-repair loop re-prompts the model if its script crashes or
+violates the I/O contract, with a reference implementation as a last-resort fallback so the
+demo always completes. The exact generated script, its input, and its output are committed
+to the branch under `validation/` so the run is fully auditable.
+
+Because that validator is LLM-written and therefore *untrusted*, lakeFS does **not** take its
+word for it. The **pre-merge Action** (`lakefs_actions/validate_ledger.yaml`) re-reads the
+committed `ledger.csv` and **independently re-derives** pass/fail — re-checking currency, the
+\$500 cap, ISO date/year, invoice-number uniqueness, and that the accepted-row count matches
+the agent's self-reported result. It does not trust `validation/latest_result.json`'s status
+field alone. So a half-processed, invalid, or self-certified ledger physically cannot be
+promoted to `main`, regardless of what code the agent ran or who triggers the merge. **E2B is
+the compute trust boundary (run unknown code safely); lakeFS is the data trust boundary
+(unknown data can't reach `main`).**
 
 ---
 
@@ -68,6 +87,8 @@ cannot be promoted, regardless of who triggers the merge.
 │   inbox/*.{jpg,png,webp,bmp,tiff,pdf}   (plain file I/O)   │
 │   archive/**                (large; never opened → lazy)   │
 │   sidecars/<file>.json      (extraction cache)             │
+│   validation/generated_validator.py  ← LLM-written, run    │
+│                                         here as a subprocess│
 │   ledger.csv / rejects.csv  (agent writes)                 │
 │   validation/latest_result.json                            │
 │                                                            │
@@ -78,7 +99,9 @@ cannot be promoted, regardless of who triggers the merge.
                  ┌──────────────────────┐
                  │      lakeFS          │
                  │  • agent branch      │
-                 │  • pre-merge gate    │  ← validation status == "passed"
+                 │  • pre-merge gate    │  ← re-validates ledger.csv
+                 │                      │    independently (doesn't
+                 │                      │    trust the agent's status)
                  └──────────┬───────────┘
                             │ merge only when the gate passes
                             ▼

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/lakefs_actions/validate_ledger.yaml
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/lakefs_actions/validate_ledger.yaml
@@ -12,13 +12,13 @@ hooks:
         local json = require("encoding/json")
         local lakefs = require("lakefs")
 
-        -- Policy constants — mirror mount_receipts/validation.py. The gate enforces these
-        -- INDEPENDENTLY: it does not trust the agent's self-reported "status", it re-derives
-        -- the verdict from the committed ledger itself. The validator that produced the
-        -- ledger was written by the LLM at runtime, so its correctness cannot be assumed —
-        -- this hook is the authoritative, non-bypassable check.
-        local POLICY_CAP = 500.0
-        local MIN_YEAR = 2023
+        -- This gate enforces the ledger policy INDEPENDENTLY. The validator that produced
+        -- the ledger was WRITTEN BY THE LLM at runtime, so its correctness cannot be
+        -- assumed — the hook re-derives accept/reject for every drafted row from typed
+        -- inputs (validation/gate_input.json) and blocks the merge if the validator
+        -- accepted any row that violates policy. It does not trust the agent's reported
+        -- status. (lakeFS's Lua has no string-pattern functions, so all checks below use
+        -- json + numbers + plain string compares only.)
         local MAX_YEAR = 2099
 
         local repo = action.repository_id
@@ -36,85 +36,93 @@ hooks:
             .. "'. Summary: " .. (result["summary"] or "unknown"))
         end
 
-        -- 2) Re-read the committed ledger and re-validate every accepted row ourselves.
-        local lrc, ledger = lakefs.get_object(repo, ref, "ledger.csv")
-        if lrc ~= 200 then
-          error("Pre-merge gate: ledger.csv not found on '" .. ref .. "'.")
+        -- 2) Re-derive the verdict for every drafted row from the typed gate inputs.
+        local grc, gbody = lakefs.get_object(repo, ref, "validation/gate_input.json")
+        if grc ~= 200 then
+          error("Pre-merge gate: validation/gate_input.json not found on '" .. ref .. "'.")
+        end
+        local gate = json.unmarshal(gbody)
+        local rows = gate["rows"] or {}
+        local today = gate["today"] or ""
+        local cap = gate["policy_cap"]
+        local min_year = gate["min_year"]
+
+        -- Count invoice numbers across the WHOLE batch so a duplicate is caught even when
+        -- its twin was rejected for another reason (and so isn't in the accepted ledger).
+        local inv_count = {}
+        for _, row in ipairs(rows) do
+          local inv = row["invoice_no"] or ""
+          if inv ~= "" then inv_count[inv] = (inv_count[inv] or 0) + 1 end
         end
 
-        -- Split a CSV line on commas. The producing code keeps the policy columns
-        -- (source_file, invoice_no, date, currency, total) comma-free and puts the
-        -- free-text `vendor` LAST, so reading fixed leading indices is safe even if a
-        -- vendor name contains commas.
-        local function split_csv(line)
-          local fields = {}
-          for field in (line .. ","):gmatch("([^,]*),") do
-            fields[#fields + 1] = field
-          end
-          return fields
-        end
-
-        local lines = {}
-        for line in ledger:gmatch("[^\r\n]+") do
-          lines[#lines + 1] = line
-        end
-
-        local problems = {}
-        local seen_invoice = {}
-        local accepted = 0
-
-        -- Row 1 is the header; every data row in ledger.csv is an accepted receipt.
-        for i = 2, #lines do
-          local f = split_csv(lines[i])
-          local source = f[1] or ("row " .. i)
-          local invoice = f[2] or ""
-          local date = f[3] or ""
-          local currency = (f[4] or ""):upper()
-          local total_s = f[5] or ""
-          accepted = accepted + 1
-
-          if currency ~= "USD" then
-            problems[#problems + 1] = source .. ": non-USD currency (" .. currency .. ")"
+        -- Returns "" if the row passes policy, or a reason string if it should be rejected.
+        local function gate_reason(row)
+          local why = ""
+          local function add(msg)
+            if why == "" then why = msg else why = why .. ", " .. msg end
           end
 
-          local total = tonumber(total_s)
+          if (row["vendor"] or "") == "" then add("missing vendor") end
+
+          local total = row["total"]   -- number, or nil when unparseable/missing
           if total == nil then
-            problems[#problems + 1] = source .. ": total not numeric (" .. total_s .. ")"
-          elseif total <= 0 then
-            problems[#problems + 1] = source .. ": non-positive total (" .. total_s .. ")"
-          elseif total > POLICY_CAP then
-            problems[#problems + 1] = source .. ": total " .. total_s .. " exceeds cap " .. POLICY_CAP
-          end
-
-          local y = date:match("^(%d%d%d%d)%-%d%d%-%d%d$")
-          if not y then
-            problems[#problems + 1] = source .. ": date not ISO YYYY-MM-DD (" .. date .. ")"
+            add("missing/unparseable total")
           else
-            local yr = tonumber(y)
-            if yr < MIN_YEAR or yr > MAX_YEAR then
-              problems[#problems + 1] = source .. ": date year out of range (" .. date .. ")"
+            if row["check_sum"] then
+              local sum = 0
+              for _, a in ipairs(row["item_amounts"] or {}) do sum = sum + a end
+              local d = total - sum
+              if d < 0 then d = -d end
+              if d > 0.01 then add("total != sum(line items)") end
             end
+            if total > cap then add("total exceeds cap " .. tostring(cap)) end
           end
 
-          if invoice ~= "" then
-            if seen_invoice[invoice] then
-              problems[#problems + 1] = source .. ": duplicate invoice number (" .. invoice .. ")"
-            end
-            seen_invoice[invoice] = true
+          local cur = row["currency"] or ""
+          if cur == "" then add("missing currency")
+          elseif cur ~= "USD" then add("non-USD currency (" .. cur .. ")") end
+
+          local diso = row["date_iso"] or ""
+          if diso == "" then
+            add("missing/unparseable date")
+          else
+            if diso > today then add("future-dated (" .. diso .. ")") end   -- ISO strings compare correctly
+            local yr = row["year"] or 0
+            if yr ~= 0 and (yr < min_year or yr > MAX_YEAR) then add("date year out of range (" .. diso .. ")") end
+          end
+
+          local inv = row["invoice_no"] or ""
+          if inv ~= "" and inv_count[inv] > 1 then add("duplicate invoice number (" .. inv .. ")") end
+
+          return why
+        end
+
+        local violations = ""
+        local nviol = 0
+        local accepted = 0
+        for _, row in ipairs(rows) do
+          if row["decided"] == "accepted" then accepted = accepted + 1 end
+          local why = gate_reason(row)
+          -- Block the dangerous direction: the validator accepted a policy-violating row.
+          if row["decided"] == "accepted" and why ~= "" then
+            local msg = (row["source_file"] or "?") .. " — " .. why
+            if violations == "" then violations = msg else violations = violations .. " | " .. msg end
+            nviol = nviol + 1
           end
         end
 
-        -- 3) Cross-check the agent's self-reported accepted count against what is actually
-        --    in the ledger — catches a half-written ledger or a doctored result file.
+        -- Cross-check the agent's self-reported accepted count against the gate inputs.
         if result["accepted"] ~= nil and result["accepted"] ~= accepted then
-          problems[#problems + 1] = "accepted-count mismatch: result claims "
-            .. tostring(result["accepted"]) .. " but ledger.csv holds " .. accepted
+          local msg = "accepted-count mismatch: result reports " .. tostring(result["accepted"])
+            .. " but gate_input has " .. accepted
+          if violations == "" then violations = msg else violations = violations .. " | " .. msg end
+          nviol = nviol + 1
         end
 
-        if #problems > 0 then
-          error("Pre-merge gate FAILED (independent re-validation found "
-            .. #problems .. " issue(s)): " .. table.concat(problems, " | "))
+        if nviol > 0 then
+          error("Pre-merge gate FAILED (independent re-validation found " .. nviol
+            .. " violation(s)): " .. violations)
         end
 
         print("Pre-merge gate PASSED: independently re-validated " .. accepted
-          .. " accepted row(s). " .. (result["summary"] or ""))
+          .. " accepted row(s) of " .. #rows .. " drafted. " .. (result["summary"] or ""))

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/lakefs_actions/validate_ledger.yaml
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/lakefs_actions/validate_ledger.yaml
@@ -12,23 +12,109 @@ hooks:
         local json = require("encoding/json")
         local lakefs = require("lakefs")
 
-        -- Read the ledger validation result the agent committed on its branch.
-        local code, body = lakefs.get_object(
-          action.repository_id,
-          action.source_ref,
-          "validation/latest_result.json"
-        )
+        -- Policy constants — mirror mount_receipts/validation.py. The gate enforces these
+        -- INDEPENDENTLY: it does not trust the agent's self-reported "status", it re-derives
+        -- the verdict from the committed ledger itself. The validator that produced the
+        -- ledger was written by the LLM at runtime, so its correctness cannot be assumed —
+        -- this hook is the authoritative, non-bypassable check.
+        local POLICY_CAP = 500.0
+        local MIN_YEAR = 2023
+        local MAX_YEAR = 2099
 
-        if code ~= 200 then
-          error("Pre-merge gate: could not find validation/latest_result.json on branch '"
-            .. action.source_ref .. "'. Run the receipts agent before merging.")
+        local repo = action.repository_id
+        local ref = action.source_ref
+
+        -- 1) The agent must have produced a validation result on its branch.
+        local rc, body = lakefs.get_object(repo, ref, "validation/latest_result.json")
+        if rc ~= 200 then
+          error("Pre-merge gate: validation/latest_result.json not found on '" .. ref
+            .. "'. Run the receipts agent before merging.")
         end
-
         local result = json.unmarshal(body)
-
         if result["status"] ~= "passed" then
-          error("Pre-merge gate FAILED: ledger did not pass validation. "
-            .. "Summary: " .. (result["summary"] or "unknown"))
+          error("Pre-merge gate FAILED: agent reported status '" .. tostring(result["status"])
+            .. "'. Summary: " .. (result["summary"] or "unknown"))
         end
 
-        print("Pre-merge gate PASSED: " .. (result["summary"] or "ok"))
+        -- 2) Re-read the committed ledger and re-validate every accepted row ourselves.
+        local lrc, ledger = lakefs.get_object(repo, ref, "ledger.csv")
+        if lrc ~= 200 then
+          error("Pre-merge gate: ledger.csv not found on '" .. ref .. "'.")
+        end
+
+        -- Split a CSV line on commas. The producing code keeps the policy columns
+        -- (source_file, invoice_no, date, currency, total) comma-free and puts the
+        -- free-text `vendor` LAST, so reading fixed leading indices is safe even if a
+        -- vendor name contains commas.
+        local function split_csv(line)
+          local fields = {}
+          for field in (line .. ","):gmatch("([^,]*),") do
+            fields[#fields + 1] = field
+          end
+          return fields
+        end
+
+        local lines = {}
+        for line in ledger:gmatch("[^\r\n]+") do
+          lines[#lines + 1] = line
+        end
+
+        local problems = {}
+        local seen_invoice = {}
+        local accepted = 0
+
+        -- Row 1 is the header; every data row in ledger.csv is an accepted receipt.
+        for i = 2, #lines do
+          local f = split_csv(lines[i])
+          local source = f[1] or ("row " .. i)
+          local invoice = f[2] or ""
+          local date = f[3] or ""
+          local currency = (f[4] or ""):upper()
+          local total_s = f[5] or ""
+          accepted = accepted + 1
+
+          if currency ~= "USD" then
+            problems[#problems + 1] = source .. ": non-USD currency (" .. currency .. ")"
+          end
+
+          local total = tonumber(total_s)
+          if total == nil then
+            problems[#problems + 1] = source .. ": total not numeric (" .. total_s .. ")"
+          elseif total <= 0 then
+            problems[#problems + 1] = source .. ": non-positive total (" .. total_s .. ")"
+          elseif total > POLICY_CAP then
+            problems[#problems + 1] = source .. ": total " .. total_s .. " exceeds cap " .. POLICY_CAP
+          end
+
+          local y = date:match("^(%d%d%d%d)%-%d%d%-%d%d$")
+          if not y then
+            problems[#problems + 1] = source .. ": date not ISO YYYY-MM-DD (" .. date .. ")"
+          else
+            local yr = tonumber(y)
+            if yr < MIN_YEAR or yr > MAX_YEAR then
+              problems[#problems + 1] = source .. ": date year out of range (" .. date .. ")"
+            end
+          end
+
+          if invoice ~= "" then
+            if seen_invoice[invoice] then
+              problems[#problems + 1] = source .. ": duplicate invoice number (" .. invoice .. ")"
+            end
+            seen_invoice[invoice] = true
+          end
+        end
+
+        -- 3) Cross-check the agent's self-reported accepted count against what is actually
+        --    in the ledger — catches a half-written ledger or a doctored result file.
+        if result["accepted"] ~= nil and result["accepted"] ~= accepted then
+          problems[#problems + 1] = "accepted-count mismatch: result claims "
+            .. tostring(result["accepted"]) .. " but ledger.csv holds " .. accepted
+        end
+
+        if #problems > 0 then
+          error("Pre-merge gate FAILED (independent re-validation found "
+            .. #problems .. " issue(s)): " .. table.concat(problems, " | "))
+        end
+
+        print("Pre-merge gate PASSED: independently re-validated " .. accepted
+          .. " accepted row(s). " .. (result["summary"] or ""))

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/agent_runner.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/agent_runner.py
@@ -17,7 +17,8 @@ is talking to lakeFS. State is passed between phases through files on the mount:
     validation/generated_validator.py (Phase-3 validator the LLM wrote at runtime)
     validation/validator_input.json   (records + policy handed to that script)
     validation/rule_outcomes.json      (per-row accept/reject the script produced)
-    ledger.csv                       (final accepted rows; gate re-validates this)
+    validation/gate_input.json         (typed rows the lakeFS gate re-validates)
+    ledger.csv                       (final accepted rows)
     rejects.csv                      (dropped + rejected rows, with reasons)
     validation/latest_result.json    (read by the lakeFS pre-merge gate)
 """
@@ -40,8 +41,11 @@ from mount_receipts.extraction import (
     sha256_file,
 )
 from mount_receipts.validation import (
+    MIN_YEAR,
     POLICY_CAP_USD,
     FileOutcome,
+    apply_cross_row_uniqueness,
+    gate_input_rows,
     validate_ledger,
 )
 
@@ -160,19 +164,42 @@ def _total_number(raw) -> str:
         return str(raw)
 
 
+def _tamper_accepted(result) -> None:
+    """Corrupt one accepted row's record in place so it violates policy (currency → EUR).
+
+    Used only when DEMO_TAMPER is set. The row's FileOutcome stays "accepted" (so the
+    self-reported result still says passed), but the committed ledger + gate inputs now
+    carry a non-USD row — which the lakeFS pre-merge gate independently rejects.
+    """
+    accepted = result.accepted
+    if not accepted:
+        print(json.dumps({"demo_tamper": "skipped — no accepted rows"}), file=sys.stderr)
+        return
+    victim = accepted[0]
+    rec = victim.record or {}
+    original = rec.get("currency")
+    rec["currency"] = "EUR"
+    print(json.dumps({"demo_tamper": "active", "row": victim.source_file,
+                      "currency": f"{original} -> EUR (gate should block this merge)"}),
+          file=sys.stderr)
+
+
 def phase_validate(root: str, model: str) -> dict:
     triage = _read_json(_p(root, "triage.json"))
     draft_doc = _read_json(_p(root, "ledger_draft.json"))
     draft = sorted(draft_doc["rows"], key=lambda r: r["source_file"])
     today = _today()
 
-    # The business-rule validator is WRITTEN BY THE MODEL at runtime and executed inside
-    # this sandbox — code we have never seen, contained by E2B. (Structural phase-1 drops
-    # and phase-2 extraction failures below stay deterministic; they were already decided.)
+    # The per-receipt validator is WRITTEN BY THE MODEL at runtime and executed inside this
+    # sandbox — code we have never seen, contained by E2B. It judges each receipt on its own
+    # (RULES_SPEC rules 1–6); the host then layers the cross-row invoice-uniqueness rule on
+    # top deterministically (LLMs reliably mishandle that whole-batch rule). Structural
+    # phase-1 drops and phase-2 extraction failures below stay deterministic too.
     gen = codegen.generate_and_run_validator(
         root, draft, today=today, policy_cap=POLICY_CAP_USD, model=model
     )
-    rule_outcomes = {o["source_file"]: o for o in gen["outcomes"]}
+    generated = {o["source_file"]: o for o in gen["outcomes"]}
+    rule_outcomes = apply_cross_row_uniqueness(draft, generated)
 
     outcomes: list[FileOutcome] = []
     # phase-1 drops
@@ -182,29 +209,46 @@ def phase_validate(root: str, model: str) -> dict:
     for d in draft_doc.get("extraction_failed", []):
         outcomes.append(FileOutcome(d["file"], "rejected", 2, d["reason"]))
 
-    # phase-3 outcomes, as decided by the generated validator
+    # phase-3 outcomes (generated per-receipt verdict + deterministic uniqueness)
+    decided: dict[str, str] = {}
     for row in draft:
         rec = row["record"]
-        o = rule_outcomes.get(row["source_file"], {"outcome": "rejected", "reasons": ["validator produced no outcome"]})
-        reasons = [r for r in (o.get("reasons") or []) if r]
-        if o.get("outcome") == "accepted" and not reasons:
+        o = rule_outcomes[row["source_file"]]
+        decided[row["source_file"]] = o["outcome"]
+        if o["outcome"] == "accepted":
             outcomes.append(FileOutcome(row["source_file"], "accepted", 3, "", rec))
         else:
-            outcomes.append(FileOutcome(row["source_file"], "rejected", 3, "; ".join(reasons) or "rejected", rec))
+            outcomes.append(FileOutcome(row["source_file"], "rejected", 3, "; ".join(o["reasons"]) or "rejected", rec))
 
     result = validate_ledger(triage["inbox"], outcomes)
 
-    # human-facing ledger + rejects. Policy-relevant columns come first and are comma-free
-    # (ISO date, currency code, numeric total); the free-text `vendor` is last so the
-    # lakeFS pre-merge hook can re-parse the ledger without a full CSV reader.
+    # DEMO_TAMPER (off by default): corrupt one accepted row AFTER it passed validation, so
+    # the agent still self-reports "passed" but the committed ledger actually violates
+    # policy — letting you watch the lakeFS gate independently catch it and block the merge.
+    if os.environ.get("DEMO_TAMPER", "").strip() not in ("", "0", "false", "False"):
+        _tamper_accepted(result)
+
+    # Typed inputs for the lakeFS pre-merge gate. The hook re-derives accept/reject for
+    # every drafted row from these primitives — independently of the LLM-written validator
+    # — and blocks the merge if the validator accepted a row that violates policy.
+    gate_rows = gate_input_rows(draft, decided)
+
+    _write_json(_p(root, "validation", "gate_input.json"), {
+        "today": today.isoformat(),
+        "policy_cap": POLICY_CAP_USD,
+        "min_year": MIN_YEAR,
+        "rows": gate_rows,
+    })
+
+    # human-facing ledger + rejects (ISO dates, numeric totals for downstream consumers)
     with open(_p(root, "ledger.csv"), "w", newline="", encoding="utf-8") as f:
         w = csv.writer(f)
-        w.writerow(["source_file", "invoice_no", "date", "currency", "total", "num_items", "vendor"])
+        w.writerow(["source_file", "vendor", "invoice_no", "date", "currency", "total", "num_items"])
         for o in result.accepted:
             r = o.record or {}
-            w.writerow([o.source_file, r.get("invoice_no", ""), _iso_date(r.get("date", "")),
-                        (r.get("currency", "") or "").upper(), _total_number(r.get("total")),
-                        len(r.get("line_items") or []), r.get("vendor", "")])
+            w.writerow([o.source_file, r.get("vendor", ""), r.get("invoice_no", ""),
+                        _iso_date(r.get("date", "")), (r.get("currency", "") or "").upper(),
+                        _total_number(r.get("total")), len(r.get("line_items") or [])])
     with open(_p(root, "rejects.csv"), "w", newline="", encoding="utf-8") as f:
         w = csv.writer(f)
         w.writerow(["source_file", "outcome", "phase", "reason"])

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/agent_runner.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/agent_runner.py
@@ -14,7 +14,10 @@ is talking to lakeFS. State is passed between phases through files on the mount:
     sidecars/<file>.json             (per-file extraction + outcome, written in triage)
     triage.json                      (kept / dropped lists)
     ledger_draft.json                (rows that reached business-rule validation)
-    ledger.csv                       (final accepted rows)
+    validation/generated_validator.py (Phase-3 validator the LLM wrote at runtime)
+    validation/validator_input.json   (records + policy handed to that script)
+    validation/rule_outcomes.json      (per-row accept/reject the script produced)
+    ledger.csv                       (final accepted rows; gate re-validates this)
     rejects.csv                      (dropped + rejected rows, with reasons)
     validation/latest_result.json    (read by the lakeFS pre-merge gate)
 """
@@ -27,6 +30,9 @@ import os
 import sys
 from datetime import date
 
+from dateutil import parser as dateparser
+
+from mount_receipts import codegen
 from mount_receipts.extraction import (
     extract,
     load_image_png,
@@ -36,7 +42,6 @@ from mount_receipts.extraction import (
 from mount_receipts.validation import (
     POLICY_CAP_USD,
     FileOutcome,
-    check_business_rules,
     validate_ledger,
 )
 
@@ -131,18 +136,43 @@ def _today() -> date:
     return date.fromisoformat(override) if override else date.today()
 
 
-def phase_validate(root: str) -> dict:
+def _iso_date(raw) -> str:
+    """Normalise an extracted date to ISO ``YYYY-MM-DD`` so the lakeFS gate can re-check it.
+
+    Accepted rows have already passed validation (date is parseable), so this rarely falls
+    through; it returns the raw string defensively if parsing ever fails.
+    """
+    try:
+        return dateparser.parse(str(raw)).date().isoformat()
+    except (ValueError, OverflowError, TypeError):
+        return str(raw or "")
+
+
+def _total_number(raw) -> str:
+    """Render ``total`` as a plain, comma-free number string for the ledger CSV / gate."""
+    if raw is None:
+        return ""
+    if isinstance(raw, (int, float)):
+        return f"{float(raw):.2f}"
+    try:
+        return f"{float(str(raw).replace(',', '').replace('$', '').strip()):.2f}"
+    except ValueError:
+        return str(raw)
+
+
+def phase_validate(root: str, model: str) -> dict:
     triage = _read_json(_p(root, "triage.json"))
     draft_doc = _read_json(_p(root, "ledger_draft.json"))
     draft = sorted(draft_doc["rows"], key=lambda r: r["source_file"])
     today = _today()
 
-    # Duplicate invoice numbers are ambiguous → every row sharing one is rejected.
-    inv_counts: dict[str, int] = {}
-    for row in draft:
-        inv = (row["record"].get("invoice_no") or "").strip()
-        if inv:
-            inv_counts[inv] = inv_counts.get(inv, 0) + 1
+    # The business-rule validator is WRITTEN BY THE MODEL at runtime and executed inside
+    # this sandbox — code we have never seen, contained by E2B. (Structural phase-1 drops
+    # and phase-2 extraction failures below stay deterministic; they were already decided.)
+    gen = codegen.generate_and_run_validator(
+        root, draft, today=today, policy_cap=POLICY_CAP_USD, model=model
+    )
+    rule_outcomes = {o["source_file"]: o for o in gen["outcomes"]}
 
     outcomes: list[FileOutcome] = []
     # phase-1 drops
@@ -152,28 +182,29 @@ def phase_validate(root: str) -> dict:
     for d in draft_doc.get("extraction_failed", []):
         outcomes.append(FileOutcome(d["file"], "rejected", 2, d["reason"]))
 
-    # phase-3 business rules
+    # phase-3 outcomes, as decided by the generated validator
     for row in draft:
         rec = row["record"]
-        reasons = check_business_rules(rec, today=today, seen_invoice_nos=set(), policy_cap=POLICY_CAP_USD)
-        inv = (rec.get("invoice_no") or "").strip()
-        if inv and inv_counts.get(inv, 0) > 1:
-            reasons.append(f"duplicate invoice number ({inv})")
-        if reasons:
-            outcomes.append(FileOutcome(row["source_file"], "rejected", 3, "; ".join(reasons), rec))
-        else:
+        o = rule_outcomes.get(row["source_file"], {"outcome": "rejected", "reasons": ["validator produced no outcome"]})
+        reasons = [r for r in (o.get("reasons") or []) if r]
+        if o.get("outcome") == "accepted" and not reasons:
             outcomes.append(FileOutcome(row["source_file"], "accepted", 3, "", rec))
+        else:
+            outcomes.append(FileOutcome(row["source_file"], "rejected", 3, "; ".join(reasons) or "rejected", rec))
 
     result = validate_ledger(triage["inbox"], outcomes)
 
-    # human-facing ledger + rejects
+    # human-facing ledger + rejects. Policy-relevant columns come first and are comma-free
+    # (ISO date, currency code, numeric total); the free-text `vendor` is last so the
+    # lakeFS pre-merge hook can re-parse the ledger without a full CSV reader.
     with open(_p(root, "ledger.csv"), "w", newline="", encoding="utf-8") as f:
         w = csv.writer(f)
-        w.writerow(["source_file", "vendor", "invoice_no", "date", "currency", "total", "num_items"])
+        w.writerow(["source_file", "invoice_no", "date", "currency", "total", "num_items", "vendor"])
         for o in result.accepted:
             r = o.record or {}
-            w.writerow([o.source_file, r.get("vendor", ""), r.get("invoice_no", ""), r.get("date", ""),
-                        r.get("currency", ""), r.get("total", ""), len(r.get("line_items") or [])])
+            w.writerow([o.source_file, r.get("invoice_no", ""), _iso_date(r.get("date", "")),
+                        (r.get("currency", "") or "").upper(), _total_number(r.get("total")),
+                        len(r.get("line_items") or []), r.get("vendor", "")])
     with open(_p(root, "rejects.csv"), "w", newline="", encoding="utf-8") as f:
         w = csv.writer(f)
         w.writerow(["source_file", "outcome", "phase", "reason"])
@@ -181,8 +212,14 @@ def phase_validate(root: str) -> dict:
             if o.outcome != "accepted":
                 w.writerow([o.source_file, o.outcome, o.phase, o.reason])
 
-    _write_json(_p(root, "validation", "latest_result.json"), result.to_dict())
-    summary = result.to_dict()
+    result_dict = result.to_dict()
+    result_dict["validator"] = {
+        "generated": gen["generated"],
+        "attempts": gen["attempts"],
+        "source": "validation/generated_validator.py" if gen["generated"] else "reference-fallback",
+    }
+    _write_json(_p(root, "validation", "latest_result.json"), result_dict)
+    summary = dict(result_dict)
     summary["phase"] = "validate"
     print(json.dumps({k: summary[k] for k in ("phase", "status", "summary", "accepted", "rejected", "dropped")}))
     return summary
@@ -202,7 +239,7 @@ def main(argv: list[str]) -> int:
     elif phase == "extract":
         phase_extract(root)
     else:
-        result = phase_validate(root)
+        result = phase_validate(root, model)
         return 0 if result["status"] == "passed" else 1
     return 0
 

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/agent_runner.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/agent_runner.py
@@ -31,7 +31,6 @@ import os
 import sys
 from datetime import date
 
-from dateutil import parser as dateparser
 
 from mount_receipts import codegen
 from mount_receipts.extraction import (
@@ -46,6 +45,7 @@ from mount_receipts.validation import (
     FileOutcome,
     apply_cross_row_uniqueness,
     gate_input_rows,
+    to_iso_date,
     validate_ledger,
 )
 
@@ -141,15 +141,8 @@ def _today() -> date:
 
 
 def _iso_date(raw) -> str:
-    """Normalise an extracted date to ISO ``YYYY-MM-DD`` so the lakeFS gate can re-check it.
-
-    Accepted rows have already passed validation (date is parseable), so this rarely falls
-    through; it returns the raw string defensively if parsing ever fails.
-    """
-    try:
-        return dateparser.parse(str(raw)).date().isoformat()
-    except (ValueError, OverflowError, TypeError):
-        return str(raw or "")
+    """ISO ``YYYY-MM-DD`` for the human-facing ledger (falls back to raw if unparseable)."""
+    return to_iso_date(raw) or str(raw or "")
 
 
 def _total_number(raw) -> str:

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/codegen.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/codegen.py
@@ -28,6 +28,7 @@ from mount_receipts.validation import (
     POLICY_CAP_USD,
     RULES_SPEC,
     business_rule_outcomes,
+    to_iso_date,
 )
 
 MAX_ATTEMPTS = 3
@@ -129,11 +130,18 @@ def generate_and_run_validator(
     output_path = os.path.join(val_dir, "rule_outcomes.json")
     script_path = os.path.join(val_dir, "generated_validator.py")
 
+    # Hand the validator ISO-normalised dates so its (LLM-written) code never does flexible
+    # date parsing — the most error-prone thing it was asked to do. All other fields pass
+    # through as extracted.
+    input_rows = [
+        {"source_file": r["source_file"], "record": {**r["record"], "date": to_iso_date(r["record"].get("date"))}}
+        for r in rows
+    ]
     payload = {
         "today": today.isoformat(),
         "policy_cap": policy_cap,
         "min_year": MIN_YEAR,
-        "rows": rows,
+        "rows": input_rows,
     }
     with open(input_path, "w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2)

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/codegen.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/codegen.py
@@ -173,9 +173,10 @@ def generate_and_run_validator(
                   file=sys.stderr)
 
     # All attempts exhausted — keep the demo runnable with the reference implementation.
+    # Per-receipt rules only (uniqueness is layered on by the host), mirroring RULES_SPEC.
     print(json.dumps({"validator": "fallback-reference", "attempts": MAX_ATTEMPTS,
                       "last_error": (last_error or "")[:500]}), file=sys.stderr)
-    outcomes = business_rule_outcomes(rows, today=today, policy_cap=policy_cap)
+    outcomes = business_rule_outcomes(rows, today=today, policy_cap=policy_cap, include_uniqueness=False)
     with open(output_path, "w", encoding="utf-8") as f:
         json.dump({"outcomes": outcomes}, f, indent=2)
     return {"outcomes": outcomes, "generated": False, "attempts": MAX_ATTEMPTS, "validator_path": None}

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/codegen.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/codegen.py
@@ -1,0 +1,181 @@
+"""Phase 3, as agent-*written* code: the model emits a validator, the sandbox runs it.
+
+In the earlier version of this demo the agent simply executed a validator we shipped in
+the repo (``validation.check_business_rules``). That worked, but it didn't need E2B —
+trusted, known code can run anywhere. Here the model is instead handed the rule
+*specification* (:data:`mount_receipts.validation.RULES_SPEC`) and the extracted receipts,
+and asked to **write a Python validator from scratch**. We then execute that
+never-before-seen script as a child process inside the sandbox.
+
+That is where E2B earns its place: we are running code we have never seen, generated at
+runtime, and the sandbox contains whatever it does. lakeFS still owns the *gate* — its
+pre-merge hook independently re-derives pass/fail from the committed ledger and does not
+trust whatever this generated code reported (see ``lakefs_actions/validate_ledger.yaml``).
+
+If the model can't produce a script that runs and conforms to the I/O contract after a
+few self-repair attempts, we fall back to the reference implementation so the demo still
+completes — but the happy path is all generated code.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+from mount_receipts.validation import (
+    MIN_YEAR,
+    POLICY_CAP_USD,
+    RULES_SPEC,
+    business_rule_outcomes,
+)
+
+MAX_ATTEMPTS = 3
+RUN_TIMEOUT_S = 120
+
+GENERATOR_SYSTEM_PROMPT = (
+    "You are a senior Python engineer. You write small, correct, self-contained command-"
+    "line scripts. You output ONLY Python source code — no prose, no markdown fences."
+)
+
+
+def _strip_fences(text: str) -> str:
+    """Remove ```python ... ``` fences if the model wrapped its answer in them."""
+    t = text.strip()
+    if t.startswith("```"):
+        lines = t.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip().startswith("```"):
+            lines = lines[:-1]
+        t = "\n".join(lines)
+    return t.strip() + "\n"
+
+
+def _build_prompt(repair_from: str | None = None, error: str | None = None) -> str:
+    if repair_from is None:
+        return (
+            "Write a complete Python 3 script that implements the following validation "
+            "specification.\n\n"
+            f"{RULES_SPEC}\n"
+            "The script must read its two path arguments from sys.argv, do the validation, "
+            "and write the output JSON. Print nothing to stdout. Exit non-zero only on an "
+            "internal error."
+        )
+    return (
+        "The validator script you wrote failed when executed. Here is the script:\n\n"
+        f"{repair_from}\n\n"
+        f"It failed with:\n{error}\n\n"
+        "Return a corrected, complete replacement script (full file, not a diff) that "
+        "satisfies the same specification and I/O contract."
+    )
+
+
+def _generate_source(model, client, *, repair_from=None, error=None) -> str:
+    resp = client.chat.completions.create(
+        model=model,
+        temperature=0,
+        messages=[
+            {"role": "system", "content": GENERATOR_SYSTEM_PROMPT},
+            {"role": "user", "content": _build_prompt(repair_from, error)},
+        ],
+    )
+    return _strip_fences(resp.choices[0].message.content or "")
+
+
+def _validate_output(doc, expected_files: set[str]) -> list[dict]:
+    """Check the generated script's output against the contract; raise ValueError if off."""
+    if not isinstance(doc, dict) or not isinstance(doc.get("outcomes"), list):
+        raise ValueError("output is not an object with an 'outcomes' list")
+    outcomes = doc["outcomes"]
+    got_files = set()
+    for o in outcomes:
+        if not isinstance(o, dict):
+            raise ValueError("each outcome must be an object")
+        sf = o.get("source_file")
+        outcome = o.get("outcome")
+        reasons = o.get("reasons", [])
+        if outcome not in ("accepted", "rejected"):
+            raise ValueError(f"bad outcome value for {sf!r}: {outcome!r}")
+        if not isinstance(reasons, list):
+            raise ValueError(f"reasons must be a list for {sf!r}")
+        got_files.add(sf)
+    if got_files != expected_files:
+        missing = expected_files - got_files
+        extra = got_files - expected_files
+        raise ValueError(f"source_file mismatch (missing={sorted(missing)}, extra={sorted(extra)})")
+    return outcomes
+
+
+def generate_and_run_validator(
+    root: str,
+    rows: list[dict],
+    *,
+    today,
+    policy_cap: float = POLICY_CAP_USD,
+    model: str,
+    client=None,
+) -> dict:
+    """Generate a validator with the LLM, run it in-sandbox, repair on failure, fall back.
+
+    Returns ``{"outcomes": [...], "generated": bool, "attempts": int,
+    "validator_path": str|None}``. The generated script, its input, and its output are
+    written under ``<root>/validation/`` so they are committed to the lakeFS branch and
+    can be audited (you can read the exact code the model ran).
+    """
+    val_dir = os.path.join(root, "validation")
+    os.makedirs(val_dir, exist_ok=True)
+    input_path = os.path.join(val_dir, "validator_input.json")
+    output_path = os.path.join(val_dir, "rule_outcomes.json")
+    script_path = os.path.join(val_dir, "generated_validator.py")
+
+    payload = {
+        "today": today.isoformat(),
+        "policy_cap": policy_cap,
+        "min_year": MIN_YEAR,
+        "rows": rows,
+    }
+    with open(input_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+    expected_files = {r["source_file"] for r in rows}
+
+    if client is None:
+        from openai import OpenAI
+
+        client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+
+    source: str | None = None
+    last_error: str | None = None
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            source = _generate_source(model, client, repair_from=source, error=last_error)
+            with open(script_path, "w", encoding="utf-8") as f:
+                f.write(source)
+
+            # Run the model's code as a child process. This is the untrusted step the E2B
+            # sandbox exists to contain.
+            proc = subprocess.run(
+                [sys.executable, script_path, input_path, output_path],
+                capture_output=True, text=True, timeout=RUN_TIMEOUT_S,
+            )
+            if proc.returncode != 0:
+                raise RuntimeError(f"exit {proc.returncode}: {(proc.stderr or proc.stdout)[-1500:]}")
+
+            with open(output_path, encoding="utf-8") as f:
+                doc = json.load(f)
+            outcomes = _validate_output(doc, expected_files)
+
+            print(json.dumps({"validator": "generated", "attempt": attempt, "rows": len(outcomes)}))
+            return {"outcomes": outcomes, "generated": True, "attempts": attempt, "validator_path": script_path}
+        except Exception as exc:  # codegen produced unrunnable / non-conforming code
+            last_error = f"{type(exc).__name__}: {exc}"
+            print(json.dumps({"validator": "generated", "attempt": attempt, "error": last_error[:500]}),
+                  file=sys.stderr)
+
+    # All attempts exhausted — keep the demo runnable with the reference implementation.
+    print(json.dumps({"validator": "fallback-reference", "attempts": MAX_ATTEMPTS,
+                      "last_error": (last_error or "")[:500]}), file=sys.stderr)
+    outcomes = business_rule_outcomes(rows, today=today, policy_cap=policy_cap)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump({"outcomes": outcomes}, f, indent=2)
+    return {"outcomes": outcomes, "generated": False, "attempts": MAX_ATTEMPTS, "validator_path": None}

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/config.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/config.py
@@ -24,6 +24,7 @@ class Config:
     openai_model: str
     # demo controls
     demo_today: str            # pin "today" for reproducible date checks; "" = real today
+    demo_tamper: str           # "1" corrupts an accepted row so the lakeFS gate blocks; "" = off
 
     def lakectl_envs(self) -> dict[str, str]:
         """Env vars everest/lakectl read inside the sandbox (creds never passed as CLI flags)."""
@@ -40,6 +41,8 @@ class Config:
         envs["OPENAI_MODEL"] = self.openai_model
         if self.demo_today:
             envs["DEMO_TODAY"] = self.demo_today
+        if self.demo_tamper:
+            envs["DEMO_TAMPER"] = self.demo_tamper
         return envs
 
 
@@ -57,4 +60,5 @@ def load_config() -> Config:
         openai_api_key=require("OPENAI_API_KEY"),
         openai_model=optional("OPENAI_MODEL", "gpt-4o"),
         demo_today=optional("DEMO_TODAY"),
+        demo_tamper=optional("DEMO_TAMPER"),
     )

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/e2b_session.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/e2b_session.py
@@ -18,7 +18,7 @@ USECASE_DIR = _HERE.parents[2]                           # usecases/03-mount-rec
 EVEREST_BIN = USECASE_DIR / "build" / "bin" / "everest"  # gitignored Linux binary
 
 # Only the modules the in-sandbox agent needs (agent_runner + its imports).
-SANDBOX_MODULES = ["__init__.py", "validation.py", "extraction.py", "agent_runner.py"]
+SANDBOX_MODULES = ["__init__.py", "validation.py", "extraction.py", "codegen.py", "agent_runner.py"]
 
 MOUNT_DIR = "/home/user/mnt"
 SANDBOX_PKG_ROOT = "/home/user"                          # so `python -m mount_receipts...` resolves

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/main.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/main.py
@@ -39,6 +39,8 @@ def main() -> int:
                 "sandbox_url": result.sandbox_url,
                 "passed": result.passed,
                 "merged": result.merged,
+                "gate_blocked": result.gate_blocked,
+                "gate_message": result.gate_message,
                 "phases": result.phases,
                 "validation": result.validation,
             },

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/orchestrator.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/orchestrator.py
@@ -58,10 +58,25 @@ class RunResult:
     merged: bool
     phases: list[dict] = field(default_factory=list)
     validation: dict | None = None
+    gate_blocked: bool = False      # the lakeFS pre-merge gate rejected the merge
+    gate_message: str = ""          # the gate's reason, when it blocked
 
 
 def _divider() -> None:
     print("─" * 60)
+
+
+def _extract_gate_reason(msg: str) -> str:
+    """Pull the human-readable gate reason out of a lakeFS pre-merge hook error blob."""
+    marker = "Pre-merge gate"
+    i = msg.find(marker)
+    reason = msg[i:] if i != -1 else msg
+    # Trim the Lua stack traceback that lakeFS appends after the message.
+    for cut in ("\\nstack traceback", "\nstack traceback"):
+        j = reason.find(cut)
+        if j != -1:
+            reason = reason[:j]
+    return reason.strip()
 
 
 def run(cfg: Config, *, source_branch: str | None = None, do_merge: bool = True, keep_sandbox: bool = False) -> RunResult:
@@ -149,11 +164,26 @@ def run(cfg: Config, *, source_branch: str | None = None, do_merge: bool = True,
 
     passed = bool(validation and validation.get("status") == "passed")
     merged = False
+    gate_blocked = False
+    gate_message = ""
     if passed and do_merge:
         print(f"\n  Merging '{branch_name}' into '{source}'...")
-        merge_ref = merge_branch(repo.branch(branch_name), repo.branch(source))
-        merged = True
-        print(f"  Merged. ref: {merge_ref}")
+        try:
+            merge_ref = merge_branch(repo.branch(branch_name), repo.branch(source))
+            merged = True
+            print(f"  Merged. ref: {merge_ref}")
+        except Exception as exc:
+            # A pre-merge hook rejection is an EXPECTED outcome — the gate independently
+            # re-validated the (LLM-written) ledger and refused a policy violation. Report
+            # it cleanly instead of crashing; the branch is left un-merged for inspection.
+            msg = str(exc)
+            if "pre-merge hook" in msg or "Pre-merge gate" in msg:
+                gate_blocked = True
+                gate_message = _extract_gate_reason(msg)
+                print(f"  Pre-merge gate BLOCKED the merge — '{branch_name}' left un-merged.")
+                print(f"  Gate: {gate_message}")
+            else:
+                raise
     elif not passed:
         print(f"\n  Validation did not pass — '{branch_name}' left un-merged for inspection.")
 
@@ -165,6 +195,8 @@ def run(cfg: Config, *, source_branch: str | None = None, do_merge: bool = True,
         merged=merged,
         phases=phase_summaries,
         validation=validation,
+        gate_blocked=gate_blocked,
+        gate_message=gate_message,
     )
 
 
@@ -181,5 +213,10 @@ def print_report(cfg: Config, result: RunResult) -> None:
         v = result.validation
         print(f"  Ledger   : {v.get('accepted')} accepted, {v.get('rejected')} rejected, {v.get('dropped')} dropped")
         print(f"  Summary  : {v.get('summary')}")
+    if result.gate_blocked:
+        # The validator passed its own check, but lakeFS's independent gate caught a
+        # policy violation it missed — exactly what the gate exists for.
+        print(f"  Gate     : BLOCKED MERGE — the LLM-written validator self-reported pass,")
+        print(f"             but lakeFS independently rejected: {result.gate_message}")
     print(f"  lakeFS UI: {cfg.lakefs_endpoint}/repositories/{cfg.lakefs_repository}/objects?ref={result.branch_name}")
     _divider()

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/validation.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/validation.py
@@ -41,10 +41,11 @@ AMOUNT_TOLERANCE = 0.01
 # and as the fallback if code generation can't produce a working validator.
 RULES_SPEC = f"""\
 You are given receipts that were already extracted into structured records. Decide, for
-each record, whether it is `accepted` or `rejected` under these business rules. A record
-is REJECTED if it violates ANY rule; list every violated rule as a short reason string.
+each record INDEPENDENTLY, whether it is `accepted` or `rejected` under these per-receipt
+business rules. A record is REJECTED if it violates ANY rule; list every violated rule as
+a short reason string.
 
-Rules:
+Rules (each applies to a single record on its own):
   1. `vendor` must be a non-empty string.
   2. `total` must be present and parseable as a number. Amounts may arrive as numbers or
      as strings like "$1,234.50" — strip "$" and thousands separators before parsing.
@@ -54,9 +55,10 @@ Rules:
      its year must be >= {MIN_YEAR}.
   5. `currency` must be present and equal to "USD" (case-insensitive).
   6. `total` must be <= the policy cap (`policy_cap`, ${POLICY_CAP_USD:.2f}).
-  7. `invoice_no` must be unique across the whole batch. If two or more records share the
-     same non-empty `invoice_no`, EVERY record carrying that number is rejected as a
-     duplicate.
+
+Do NOT implement cross-record / uniqueness checks — the host enforces invoice-number
+uniqueness deterministically after your validator runs (and the lakeFS pre-merge gate
+independently re-checks ALL rules, including uniqueness). Judge each record by itself.
 
 I/O contract for the script you write:
   - It is invoked as:  python <script> <input_json_path> <output_json_path>
@@ -181,13 +183,50 @@ def business_rule_outcomes(
     *,
     today: date,
     policy_cap: float = POLICY_CAP_USD,
+    include_uniqueness: bool = True,
 ) -> list[dict]:
-    """Reference implementation of :data:`RULES_SPEC` over the drafted rows.
+    """Reference implementation of the business rules over the drafted rows.
 
     ``rows`` is the ``ledger_draft.json`` shape: ``[{"source_file": str, "record": {...}}]``.
-    Returns one ``{"source_file", "outcome", "reasons"}`` dict per row. This is exactly
-    what the LLM-generated validator is asked to reproduce; it is used by the unit tests
-    and as the fallback when code generation fails (see ``codegen.generate_and_run_validator``).
+    Returns one ``{"source_file", "outcome", "reasons"}`` dict per row.
+
+    With ``include_uniqueness=True`` this is the complete policy (the unit-test oracle).
+    With ``include_uniqueness=False`` it covers only the per-receipt rules — matching what
+    the LLM-generated validator is asked to produce (see :data:`RULES_SPEC`); the host then
+    layers cross-row uniqueness on top via :func:`apply_cross_row_uniqueness`. The
+    code-generation fallback uses the ``False`` variant so both paths behave identically.
+    """
+    inv_counts: dict[str, int] = {}
+    if include_uniqueness:
+        for row in rows:
+            inv = (row["record"].get("invoice_no") or "").strip()
+            if inv:
+                inv_counts[inv] = inv_counts.get(inv, 0) + 1
+
+    outcomes: list[dict] = []
+    for row in sorted(rows, key=lambda r: r["source_file"]):
+        rec = row["record"]
+        reasons = check_business_rules(rec, today=today, seen_invoice_nos=set(), policy_cap=policy_cap)
+        if include_uniqueness:
+            inv = (rec.get("invoice_no") or "").strip()
+            if inv and inv_counts.get(inv, 0) > 1:
+                reasons.append(f"duplicate invoice number ({inv})")
+        outcomes.append({
+            "source_file": row["source_file"],
+            "outcome": "rejected" if reasons else "accepted",
+            "reasons": reasons,
+        })
+    return outcomes
+
+
+def apply_cross_row_uniqueness(rows: list[dict], generated: dict[str, dict]) -> dict[str, dict]:
+    """Layer deterministic invoice-number uniqueness on top of the per-receipt verdicts.
+
+    The LLM-generated validator judges each receipt on its own (RULES_SPEC rules 1–6) — it
+    reliably mishandles the cross-row uniqueness rule, so the host owns that one rule here.
+    ``generated`` maps source_file -> {"outcome", "reasons"} (the validator's per-receipt
+    verdict). Any row whose non-empty invoice number repeats across the batch is rejected
+    with a duplicate reason. Returns the final source_file -> {"outcome", "reasons"} map.
     """
     inv_counts: dict[str, int] = {}
     for row in rows:
@@ -195,19 +234,62 @@ def business_rule_outcomes(
         if inv:
             inv_counts[inv] = inv_counts.get(inv, 0) + 1
 
-    outcomes: list[dict] = []
-    for row in sorted(rows, key=lambda r: r["source_file"]):
-        rec = row["record"]
-        reasons = check_business_rules(rec, today=today, seen_invoice_nos=set(), policy_cap=policy_cap)
-        inv = (rec.get("invoice_no") or "").strip()
+    final: dict[str, dict] = {}
+    for row in rows:
+        sf = row["source_file"]
+        g = generated.get(sf, {"outcome": "rejected", "reasons": ["validator produced no outcome"]})
+        reasons = [r for r in (g.get("reasons") or []) if r]
+        inv = (row["record"].get("invoice_no") or "").strip()
         if inv and inv_counts.get(inv, 0) > 1:
             reasons.append(f"duplicate invoice number ({inv})")
-        outcomes.append({
-            "source_file": row["source_file"],
-            "outcome": "rejected" if reasons else "accepted",
-            "reasons": reasons,
+        accepted = g.get("outcome") == "accepted" and not reasons
+        final[sf] = {"outcome": "accepted" if accepted else "rejected", "reasons": reasons}
+    return final
+
+
+def gate_input_rows(rows: list[dict], decided: dict[str, str]) -> list[dict]:
+    """Project the drafted rows into typed fields the lakeFS pre-merge hook re-validates.
+
+    The hook cannot parse dates or arbitrary CSV in its (pattern-less) Lua runtime, so the
+    host normalises each drafted row here into primitives the hook can re-check with plain
+    arithmetic and string compares: parsed ``total``/amounts, an ISO ``date``, the ``year``,
+    and the validator's ``decided`` verdict for the row. The hook independently re-derives
+    accept/reject from these fields and blocks the merge if the (LLM-written) validator
+    accepted a row that violates policy. ``decided`` maps source_file -> "accepted"|"rejected".
+
+    Note this is *data preparation*, not the verdict: the policy decision is re-made in Lua.
+    """
+    out: list[dict] = []
+    for row in sorted(rows, key=lambda r: r["source_file"]):
+        rec = row["record"]
+        sf = row["source_file"]
+        total = _parse_amount(rec.get("total"))
+        items = rec.get("line_items") or []
+        amounts = [_parse_amount(it.get("amount") if isinstance(it, dict) else None) for it in items]
+        all_parseable = items and all(a is not None for a in amounts)
+
+        raw_date = (rec.get("date") or "").strip()
+        date_iso, year = "", 0
+        if raw_date:
+            try:
+                parsed = dateparser.parse(raw_date).date()
+                date_iso, year = parsed.isoformat(), parsed.year
+            except (ValueError, OverflowError, TypeError):
+                date_iso, year = "", 0
+
+        out.append({
+            "source_file": sf,
+            "decided": decided.get(sf, "rejected"),
+            "vendor": (rec.get("vendor") or "").strip(),
+            "currency": (rec.get("currency") or "").strip().upper(),
+            "total": total,                      # JSON null when unparseable/missing
+            "item_amounts": [a for a in amounts if a is not None] if all_parseable else [],
+            "check_sum": bool(all_parseable),
+            "date_iso": date_iso,                # "" when missing/unparseable
+            "year": year,                        # 0 when unknown
+            "invoice_no": (rec.get("invoice_no") or "").strip(),
         })
-    return outcomes
+    return out
 
 
 @dataclass

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/validation.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/validation.py
@@ -51,8 +51,9 @@ Rules (each applies to a single record on its own):
      as strings like "$1,234.50" — strip "$" and thousands separators before parsing.
   3. If `line_items` is non-empty, `total` must equal the sum of the item `amount`s,
      within a tolerance of {AMOUNT_TOLERANCE}.
-  4. `date` must be present and parseable, must NOT be in the future (after `today`), and
-     its year must be >= {MIN_YEAR}.
+  4. `date` is given as an ISO `YYYY-MM-DD` string ("" if it was missing/unparseable). It
+     must be non-empty, must NOT be after `today` (also ISO `YYYY-MM-DD` — compare the two
+     strings directly, do NOT re-parse), and its year (first 4 chars) must be >= {MIN_YEAR}.
   5. `currency` must be present and equal to "USD" (case-insensitive).
   6. `total` must be <= the policy cap (`policy_cap`, ${POLICY_CAP_USD:.2f}).
 
@@ -68,6 +69,8 @@ I/O contract for the script you write:
                    "record": {{"vendor": str, "date": str, "invoice_no": str,
                                "currency": str, "total": <number|string|null>,
                                "line_items": [{{"name": str, "amount": <number|string>}}]}}}}]}}
+    `record.date` is pre-normalised to ISO `YYYY-MM-DD` (or "" if it couldn't be parsed) and
+    `today` is ISO `YYYY-MM-DD`; other fields are as extracted (amounts may be strings).
   - It must write the output JSON with shape:
       {{"outcomes": [{{"source_file": str, "outcome": "accepted"|"rejected",
                        "reasons": [str]}}]}}
@@ -95,6 +98,22 @@ class FileOutcome:
             "reason": self.reason,
             "record": self.record,
         }
+
+
+def to_iso_date(raw) -> str:
+    """Normalise an extracted date (any printed format) to ISO ``YYYY-MM-DD``.
+
+    Returns ``""`` if missing/unparseable. The host runs this before handing receipts to the
+    generated validator, so the LLM-written code compares plain ISO strings instead of doing
+    flexible date parsing — the most error-prone thing it was asked to do.
+    """
+    raw = (str(raw).strip() if raw is not None else "")
+    if not raw:
+        return ""
+    try:
+        return dateparser.parse(raw).date().isoformat()
+    except (ValueError, OverflowError, TypeError):
+        return ""
 
 
 def _parse_amount(value) -> float | None:
@@ -268,14 +287,8 @@ def gate_input_rows(rows: list[dict], decided: dict[str, str]) -> list[dict]:
         amounts = [_parse_amount(it.get("amount") if isinstance(it, dict) else None) for it in items]
         all_parseable = items and all(a is not None for a in amounts)
 
-        raw_date = (rec.get("date") or "").strip()
-        date_iso, year = "", 0
-        if raw_date:
-            try:
-                parsed = dateparser.parse(raw_date).date()
-                date_iso, year = parsed.isoformat(), parsed.year
-            except (ValueError, OverflowError, TypeError):
-                date_iso, year = "", 0
+        date_iso = to_iso_date(rec.get("date"))
+        year = int(date_iso[:4]) if date_iso else 0
 
         out.append({
             "source_file": sf,

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/validation.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/src/mount_receipts/validation.py
@@ -31,6 +31,51 @@ MIN_YEAR = 2023
 AMOUNT_TOLERANCE = 0.01
 
 
+# The Phase-3 business rules, written as a *specification* rather than as the code that
+# enforces them. At runtime the agent is handed this spec plus the extracted receipts and
+# is asked to WRITE its own Python validator, which is then executed inside the E2B
+# sandbox (see ``codegen.py``). That is the whole point of running it in E2B: the
+# validation logic is code we have never seen until the model emits it, and the sandbox
+# contains whatever it does. ``check_business_rules`` / ``business_rule_outcomes`` below
+# are the canonical reference implementation of this same spec — used by the unit tests
+# and as the fallback if code generation can't produce a working validator.
+RULES_SPEC = f"""\
+You are given receipts that were already extracted into structured records. Decide, for
+each record, whether it is `accepted` or `rejected` under these business rules. A record
+is REJECTED if it violates ANY rule; list every violated rule as a short reason string.
+
+Rules:
+  1. `vendor` must be a non-empty string.
+  2. `total` must be present and parseable as a number. Amounts may arrive as numbers or
+     as strings like "$1,234.50" — strip "$" and thousands separators before parsing.
+  3. If `line_items` is non-empty, `total` must equal the sum of the item `amount`s,
+     within a tolerance of {AMOUNT_TOLERANCE}.
+  4. `date` must be present and parseable, must NOT be in the future (after `today`), and
+     its year must be >= {MIN_YEAR}.
+  5. `currency` must be present and equal to "USD" (case-insensitive).
+  6. `total` must be <= the policy cap (`policy_cap`, ${POLICY_CAP_USD:.2f}).
+  7. `invoice_no` must be unique across the whole batch. If two or more records share the
+     same non-empty `invoice_no`, EVERY record carrying that number is rejected as a
+     duplicate.
+
+I/O contract for the script you write:
+  - It is invoked as:  python <script> <input_json_path> <output_json_path>
+  - The input JSON has shape:
+      {{"today": "YYYY-MM-DD", "policy_cap": <number>, "min_year": <int>,
+        "rows": [{{"source_file": str,
+                   "record": {{"vendor": str, "date": str, "invoice_no": str,
+                               "currency": str, "total": <number|string|null>,
+                               "line_items": [{{"name": str, "amount": <number|string>}}]}}}}]}}
+  - It must write the output JSON with shape:
+      {{"outcomes": [{{"source_file": str, "outcome": "accepted"|"rejected",
+                       "reasons": [str]}}]}}
+    with EXACTLY ONE outcome per input row (same `source_file`s), and reasons empty for
+    accepted rows.
+  - You may use the Python standard library and `python-dateutil` (already installed).
+    Do NOT use the network or any other third-party package.
+"""
+
+
 @dataclass
 class FileOutcome:
     """Final disposition of a single inbox file."""
@@ -129,6 +174,40 @@ def check_business_rules(
         reasons.append(f"duplicate invoice number ({invoice_no})")
 
     return reasons
+
+
+def business_rule_outcomes(
+    rows: list[dict],
+    *,
+    today: date,
+    policy_cap: float = POLICY_CAP_USD,
+) -> list[dict]:
+    """Reference implementation of :data:`RULES_SPEC` over the drafted rows.
+
+    ``rows`` is the ``ledger_draft.json`` shape: ``[{"source_file": str, "record": {...}}]``.
+    Returns one ``{"source_file", "outcome", "reasons"}`` dict per row. This is exactly
+    what the LLM-generated validator is asked to reproduce; it is used by the unit tests
+    and as the fallback when code generation fails (see ``codegen.generate_and_run_validator``).
+    """
+    inv_counts: dict[str, int] = {}
+    for row in rows:
+        inv = (row["record"].get("invoice_no") or "").strip()
+        if inv:
+            inv_counts[inv] = inv_counts.get(inv, 0) + 1
+
+    outcomes: list[dict] = []
+    for row in sorted(rows, key=lambda r: r["source_file"]):
+        rec = row["record"]
+        reasons = check_business_rules(rec, today=today, seen_invoice_nos=set(), policy_cap=policy_cap)
+        inv = (rec.get("invoice_no") or "").strip()
+        if inv and inv_counts.get(inv, 0) > 1:
+            reasons.append(f"duplicate invoice number ({inv})")
+        outcomes.append({
+            "source_file": row["source_file"],
+            "outcome": "rejected" if reasons else "accepted",
+            "reasons": reasons,
+        })
+    return outcomes
 
 
 @dataclass

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/tests/test_codegen.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/tests/test_codegen.py
@@ -21,7 +21,8 @@ import json, sys
 from datetime import date
 from mount_receipts.validation import business_rule_outcomes
 inp = json.load(open(sys.argv[1]))
-out = business_rule_outcomes(inp["rows"], today=date.fromisoformat(inp["today"]), policy_cap=inp["policy_cap"])
+out = business_rule_outcomes(inp["rows"], today=date.fromisoformat(inp["today"]),
+                             policy_cap=inp["policy_cap"], include_uniqueness=False)
 json.dump({"outcomes": out}, open(sys.argv[2], "w"))
 """
 
@@ -105,8 +106,8 @@ def test_falls_back_to_reference_after_exhaustion(tmp_path):
 
     assert res["generated"] is False
     assert res["attempts"] == codegen.MAX_ATTEMPTS
-    # Fallback output must match the canonical reference exactly.
-    assert res["outcomes"] == business_rule_outcomes(rows, today=TODAY)
+    # Fallback output must match the per-receipt reference (uniqueness added later by host).
+    assert res["outcomes"] == business_rule_outcomes(rows, today=TODAY, include_uniqueness=False)
     # The contract output file is still written so downstream/audit stays consistent.
     doc = json.load(open(tmp_path / "validation" / "rule_outcomes.json"))
     assert {o["source_file"] for o in doc["outcomes"]} == {"ok.jpg", "bad.jpg"}

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/tests/test_codegen.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/tests/test_codegen.py
@@ -1,0 +1,112 @@
+"""Tests for the code-generation harness (no OpenAI calls — the client is stubbed).
+
+These exercise the generate → write → run-in-subprocess → schema-check → repair → fallback
+flow. The "model" returns canned Python scripts so the harness runs entirely offline.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import date
+
+from mount_receipts import codegen
+from mount_receipts.validation import business_rule_outcomes
+
+TODAY = date(2026, 6, 5)
+
+# A correct validator, expressed via the package's reference implementation. Stands in for
+# what a capable model would emit; proves the harness runs generated code end to end.
+GOOD_SCRIPT = """\
+import json, sys
+from datetime import date
+from mount_receipts.validation import business_rule_outcomes
+inp = json.load(open(sys.argv[1]))
+out = business_rule_outcomes(inp["rows"], today=date.fromisoformat(inp["today"]), policy_cap=inp["policy_cap"])
+json.dump({"outcomes": out}, open(sys.argv[2], "w"))
+"""
+
+# Conforms to the contract but is wrong about *which* rows — forces a schema repair.
+WRONG_SHAPE_SCRIPT = """\
+import json, sys
+json.dump({"outcomes": [{"source_file": "ghost.jpg", "outcome": "accepted", "reasons": []}]}, open(sys.argv[2], "w"))
+"""
+
+BROKEN_SCRIPT = "this is not valid python :("
+
+
+class _Msg:
+    def __init__(self, content):
+        self.content = content
+
+
+class _Choice:
+    def __init__(self, content):
+        self.message = _Msg(content)
+
+
+class _Resp:
+    def __init__(self, content):
+        self.choices = [_Choice(content)]
+
+
+class _Completions:
+    def __init__(self, scripts):
+        self._scripts = scripts
+        self.calls = 0
+
+    def create(self, **kwargs):
+        script = self._scripts[min(self.calls, len(self._scripts) - 1)]
+        self.calls += 1
+        return _Resp(script)
+
+
+class _StubClient:
+    """Returns canned scripts in order; repeats the last one once exhausted."""
+    def __init__(self, scripts):
+        self.chat = type("_Chat", (), {"completions": _Completions(scripts)})()
+
+
+def _rows():
+    rec = dict(vendor="Acme", invoice_no="OK-1", date="2026-01-10", currency="USD",
+               line_items=[{"name": "x", "amount": 10.0}], total=10.0)
+    bad = dict(rec, invoice_no="BAD-1", currency="EUR")
+    return [{"source_file": "ok.jpg", "record": rec}, {"source_file": "bad.jpg", "record": dict(bad)}]
+
+
+def test_generated_validator_runs_and_is_used(tmp_path):
+    rows = _rows()
+    client = _StubClient([GOOD_SCRIPT])
+    res = codegen.generate_and_run_validator(str(tmp_path), rows, today=TODAY, model="x", client=client)
+
+    assert res["generated"] is True
+    assert res["attempts"] == 1
+    # The generated script and its committed artefacts are on disk for audit.
+    assert os.path.exists(tmp_path / "validation" / "generated_validator.py")
+    assert os.path.exists(tmp_path / "validation" / "rule_outcomes.json")
+    by_file = {o["source_file"]: o for o in res["outcomes"]}
+    assert by_file["ok.jpg"]["outcome"] == "accepted"
+    assert by_file["bad.jpg"]["outcome"] == "rejected"
+
+
+def test_schema_mismatch_triggers_repair(tmp_path):
+    rows = _rows()
+    # First attempt returns the wrong rows (schema check fails), second is correct.
+    client = _StubClient([WRONG_SHAPE_SCRIPT, GOOD_SCRIPT])
+    res = codegen.generate_and_run_validator(str(tmp_path), rows, today=TODAY, model="x", client=client)
+
+    assert res["generated"] is True
+    assert res["attempts"] == 2
+
+
+def test_falls_back_to_reference_after_exhaustion(tmp_path):
+    rows = _rows()
+    client = _StubClient([BROKEN_SCRIPT])  # never runs → all attempts fail
+    res = codegen.generate_and_run_validator(str(tmp_path), rows, today=TODAY, model="x", client=client)
+
+    assert res["generated"] is False
+    assert res["attempts"] == codegen.MAX_ATTEMPTS
+    # Fallback output must match the canonical reference exactly.
+    assert res["outcomes"] == business_rule_outcomes(rows, today=TODAY)
+    # The contract output file is still written so downstream/audit stays consistent.
+    doc = json.load(open(tmp_path / "validation" / "rule_outcomes.json"))
+    assert {o["source_file"] for o in doc["outcomes"]} == {"ok.jpg", "bad.jpg"}

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/tests/test_validation.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/tests/test_validation.py
@@ -7,8 +7,10 @@ import pytest
 
 from mount_receipts.validation import (
     FileOutcome,
+    apply_cross_row_uniqueness,
     business_rule_outcomes,
     check_business_rules,
+    gate_input_rows,
     validate_ledger,
 )
 
@@ -144,7 +146,61 @@ def test_outcomes_reject_both_sides_of_a_duplicate_invoice():
     assert all(any("duplicate invoice" in r for r in o["reasons"]) for o in out)
 
 
+def test_outcomes_without_uniqueness_ignores_duplicates():
+    # The per-receipt variant (what the LLM validator produces) must NOT flag duplicates.
+    rows = [_row("a.jpg", invoice_no="DUP"), _row("b.jpg", invoice_no="DUP")]
+    out = business_rule_outcomes(rows, today=TODAY, include_uniqueness=False)
+    assert all(o["outcome"] == "accepted" for o in out)
+
+
+# --- apply_cross_row_uniqueness (the host's deterministic duplicate pass) --------
+
+def test_uniqueness_rejects_duplicates_the_validator_accepted():
+    rows = [_row("a.jpg", invoice_no="DUP"), _row("b.jpg", invoice_no="DUP"), _row("c.jpg", invoice_no="UNIQ")]
+    # The generated validator (per-receipt only) accepted all three.
+    generated = {f: {"outcome": "accepted", "reasons": []} for f in ("a.jpg", "b.jpg", "c.jpg")}
+    final = apply_cross_row_uniqueness(rows, generated)
+    assert final["a.jpg"]["outcome"] == "rejected" and any("duplicate" in r for r in final["a.jpg"]["reasons"])
+    assert final["b.jpg"]["outcome"] == "rejected"
+    assert final["c.jpg"]["outcome"] == "accepted"
+
+
+def test_uniqueness_preserves_prior_rejections():
+    rows = [_row("a.jpg", invoice_no="X")]
+    generated = {"a.jpg": {"outcome": "rejected", "reasons": ["non-USD currency (EUR)"]}}
+    final = apply_cross_row_uniqueness(rows, generated)
+    assert final["a.jpg"]["outcome"] == "rejected"
+    assert final["a.jpg"]["reasons"] == ["non-USD currency (EUR)"]
+
+
+def test_uniqueness_defaults_missing_outcome_to_rejected():
+    rows = [_row("a.jpg", invoice_no="X")]
+    final = apply_cross_row_uniqueness(rows, {})   # validator produced nothing for this row
+    assert final["a.jpg"]["outcome"] == "rejected"
+
+
 def test_outcomes_one_per_row():
     rows = [_row("a.jpg", invoice_no="A"), _row("b.jpg", invoice_no="B"), _row("c.jpg", invoice_no="C")]
     out = business_rule_outcomes(rows, today=TODAY)
     assert {o["source_file"] for o in out} == {"a.jpg", "b.jpg", "c.jpg"}
+
+
+# --- gate_input_rows (typed inputs the lakeFS hook re-validates) ----------------
+
+def test_gate_input_typing_and_normalisation():
+    rows = [_row("r.jpg", date="1/20/2026", currency="usd", total="$10.00",
+                 line_items=[{"name": "x", "amount": "4.00"}, {"name": "y", "amount": "6.00"}])]
+    g = gate_input_rows(rows, {"r.jpg": "accepted"})[0]
+    assert g["decided"] == "accepted"
+    assert g["currency"] == "USD"            # upper-cased
+    assert g["total"] == 10.0                # parsed from "$10.00"
+    assert g["date_iso"] == "2026-01-20" and g["year"] == 2026   # normalised to ISO
+    assert g["item_amounts"] == [4.0, 6.0] and g["check_sum"] is True
+
+
+def test_gate_input_unparseable_total_is_null_and_decided_defaults_rejected():
+    rows = [_row("r.jpg", total="N/A", line_items=[])]
+    g = gate_input_rows(rows, {})[0]      # no decision provided
+    assert g["total"] is None
+    assert g["check_sum"] is False and g["item_amounts"] == []
+    assert g["decided"] == "rejected"     # safe default when the validator gave no outcome

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/tests/test_validation.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/tests/test_validation.py
@@ -11,8 +11,17 @@ from mount_receipts.validation import (
     business_rule_outcomes,
     check_business_rules,
     gate_input_rows,
+    to_iso_date,
     validate_ledger,
 )
+
+
+def test_to_iso_date_normalises_and_handles_bad_input():
+    assert to_iso_date("2026-03-12") == "2026-03-12"
+    assert to_iso_date("1/20/2026") == "2026-01-20"   # any printed format -> ISO
+    assert to_iso_date("") == ""
+    assert to_iso_date(None) == ""
+    assert to_iso_date("not a date") == ""
 
 TODAY = date(2026, 6, 5)
 

--- a/01_standalone_examples/e2b/usecases/03-mount-receipts/tests/test_validation.py
+++ b/01_standalone_examples/e2b/usecases/03-mount-receipts/tests/test_validation.py
@@ -7,6 +7,7 @@ import pytest
 
 from mount_receipts.validation import (
     FileOutcome,
+    business_rule_outcomes,
     check_business_rules,
     validate_ledger,
 )
@@ -120,3 +121,30 @@ def test_unexpected_file_fails():
     res = validate_ledger(["a.jpg"], [_acc("a.jpg"), _acc("ghost.jpg")])
     assert not res.passed
     assert "unexpected" in res.summary
+
+
+# --- business_rule_outcomes (the spec the generated validator reproduces) -------
+
+def _row(f, **kw):
+    return {"source_file": f, "record": _rec(**kw)}
+
+
+def test_outcomes_accept_and_reject():
+    rows = [_row("ok.jpg", invoice_no="OK-1"), _row("bad.jpg", invoice_no="BAD-1", currency="EUR")]
+    out = {o["source_file"]: o for o in business_rule_outcomes(rows, today=TODAY)}
+    assert out["ok.jpg"]["outcome"] == "accepted" and out["ok.jpg"]["reasons"] == []
+    assert out["bad.jpg"]["outcome"] == "rejected"
+    assert any("non-USD" in r for r in out["bad.jpg"]["reasons"])
+
+
+def test_outcomes_reject_both_sides_of_a_duplicate_invoice():
+    rows = [_row("a.jpg", invoice_no="DUP"), _row("b.jpg", invoice_no="DUP")]
+    out = business_rule_outcomes(rows, today=TODAY)
+    assert all(o["outcome"] == "rejected" for o in out)
+    assert all(any("duplicate invoice" in r for r in o["reasons"]) for o in out)
+
+
+def test_outcomes_one_per_row():
+    rows = [_row("a.jpg", invoice_no="A"), _row("b.jpg", invoice_no="B"), _row("c.jpg", invoice_no="C")]
+    out = business_rule_outcomes(rows, today=TODAY)
+    assert {o["source_file"] for o in out} == {"a.jpg", "b.jpg", "c.jpg"}


### PR DESCRIPTION
## Motivation — feedback from E2B

> I would modify the validator to be an **agent-generated script** rather than having the agent simply execute `validation.py`, because right now lakeFS already blocks anything that doesn't pass. The validator prompt should be something like *"here are the extracted receipts, write a Python script that validates them based on these rules."* If the validation logic is generated by the LLM at runtime and executed in the sandbox, **E2B earns its place: you're now running code you've never seen before, and the sandbox prevents any unexpected behavior from escaping.**

This PR implements that, scoped to **use case 3 (`03-mount-receipts`)** only.

## What changed

**Phase-3 validation is now agent-generated at runtime (E2B earns its keep).** Instead of executing a static `validation.py`, the agent is handed the rule *spec* + the extracted receipts and **writes its own Python validator**, which is then executed as a child process inside the E2B sandbox — code we've never seen, contained by the sandbox. A self-repair loop re-prompts on crashes/contract violations, with a reference implementation as a last-resort fallback. The generated script, its input, and its output are committed under `validation/` for audit (`codegen.py`).

**lakeFS no longer takes the validator's word for it.** Because the validator is LLM-written and therefore untrusted, the pre-merge hook (`validate_ledger.yaml`) was rewritten to **independently re-derive** accept/reject for every drafted row from a typed `gate_input.json` — re-checking `total == sum(items)`, the cap, currency, ISO date/year, **and** invoice-number uniqueness across the whole batch — and blocks the merge on any violation. It does not trust the agent's self-reported status. (lakeFS Lua has no string-pattern functions, so the hook uses `json` + numeric/string ops only.)

**Reliability + demonstrability:**
- The host pre-normalizes the inputs LLMs reliably get wrong — cross-row invoice uniqueness and date formats (dates → ISO `YYYY-MM-DD`) — so the happy path merges reliably, while the LLM still writes the per-receipt rule logic. lakeFS's gate independently re-checks everything regardless. (Both were real failure modes observed on live runs: a generated validator that silently dropped duplicate detection, and one that compared a `datetime` to a `date` and rejected every receipt — exactly why the independent gate matters.)
- `DEMO_TAMPER=1` corrupts one accepted row after validation so you can watch the lakeFS gate independently block a bad merge on demand.

## Trust boundaries

**E2B = compute trust boundary** (run unknown code safely). **lakeFS = data trust boundary** (unknown data can't reach `main`). The two reinforce each other rather than overlap.

## Verified live (lakeFS Cloud + E2B + gpt-4o)

- default run → `4 accepted / 5 rejected / 4 dropped` → gate passes → **merged to `main`**
- `DEMO_TAMPER=1` → validator self-reports pass → lakeFS gate **independently rejects** the non-USD row → merge blocked, reported cleanly

27 unit tests pass (offline; OpenAI client stubbed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)