### PR TITLE
Add standalone example: lakeFS with OneBucket S3-compatible storage

### DIFF
--- a/01_standalone_examples/lakefs-onebucket/.env.example
+++ b/01_standalone_examples/lakefs-onebucket/.env.example
@@ -1,0 +1,61 @@
+# ─── OneBucket / S3-compatible backend ──────────────────────────────────────
+# The endpoint lakeFS will use as its blockstore (and check_onebucket.py uses
+# for direct validation). Must include scheme: https://... or http://...
+ONEBUCKET_ENDPOINT=https://example.onebucket.endpoint
+
+ONEBUCKET_ACCESS_KEY_ID=replace-me
+ONEBUCKET_SECRET_ACCESS_KEY=replace-me
+
+# The bucket that lakeFS will write its blockstore objects into.
+# Do NOT include this in ONEBUCKET_ENDPOINT.
+ONEBUCKET_BUCKET=my-bucket
+
+# Region string — many S3-compatible systems accept any value (e.g. us-east-1).
+# Leave as-is unless your endpoint requires a specific region.
+ONEBUCKET_REGION=us-east-1
+
+# Use path-style URLs (recommended for OneBucket and most S3-compatible stores).
+ONEBUCKET_FORCE_PATH_STYLE=true
+
+# Set to true if OneBucket uses a self-signed or private CA certificate.
+ONEBUCKET_SKIP_VERIFY=false
+
+# ─── lakeFS service ─────────────────────────────────────────────────────────
+# URL where the lakeFS API and S3 Gateway are reachable from your machine.
+LAKEFS_ENDPOINT=http://localhost:8000
+
+# Credentials for the lakeFS admin user.
+# These are created automatically on first start via LAKEFS_INSTALLATION_* in
+# docker-compose.yml. Use any stable values you choose.
+LAKEFS_ACCESS_KEY_ID=replace-me
+LAKEFS_SECRET_ACCESS_KEY=replace-me
+
+# Secret used to encrypt auth tokens. Generate with: openssl rand -hex 32
+LAKEFS_AUTH_ENCRYPT_SECRET_KEY=replace-with-openssl-rand-hex-32
+
+# Secret used to sign S3 pre-signed URLs. Generate with: openssl rand -hex 32
+LAKEFS_BLOCKSTORE_SIGNING_SECRET_KEY=replace-with-openssl-rand-hex-32
+
+# ─── lakeFS repository ──────────────────────────────────────────────────────
+# Whether make init should auto-create the repository.
+# Set to false to validate and use an existing manually-created repo instead.
+CREATE_LAKEFS_REPO=true
+
+LAKEFS_REPO=onebucket-demo
+LAKEFS_BRANCH=main
+
+# Where lakeFS stores its blockstore objects inside the OneBucket bucket.
+# Must start with s3://  Use a prefix to isolate demo data from other content.
+# If empty, the default is: s3://<ONEBUCKET_BUCKET>/lakefs/<LAKEFS_REPO>/
+LAKEFS_STORAGE_NAMESPACE=s3://my-bucket/lakefs/onebucket-demo/
+
+# ─── Demo behavior ───────────────────────────────────────────────────────────
+# Set to true in run_demo.py to merge the experiment branch back to main.
+MERGE_EXPERIMENT=false
+
+# ─── Postgres (local metadata store) ────────────────────────────────────────
+POSTGRES_USER=lakefs
+POSTGRES_PASSWORD=lakefs
+POSTGRES_DB=lakefs
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432

--- a/01_standalone_examples/lakefs-onebucket/.env.example
+++ b/01_standalone_examples/lakefs-onebucket/.env.example
@@ -25,8 +25,8 @@ ONEBUCKET_SKIP_VERIFY=false
 LAKEFS_ENDPOINT=http://localhost:8000
 
 # Credentials for the lakeFS admin user.
-# These are created automatically on first start via LAKEFS_INSTALLATION_* in
-# docker-compose.yml. Use any stable values you choose.
+# The lakeFS container runs `lakefs setup` with these values on first start
+# (see docker-compose.yml). Use any stable values you choose.
 LAKEFS_ACCESS_KEY_ID=replace-me
 LAKEFS_SECRET_ACCESS_KEY=replace-me
 

--- a/01_standalone_examples/lakefs-onebucket/.gitignore
+++ b/01_standalone_examples/lakefs-onebucket/.gitignore
@@ -1,0 +1,43 @@
+# Credentials — NEVER commit any .env file except .env.example
+# This pattern catches .env, .env.local, .env.production, .env.staging, etc.
+.env
+.env.*
+# Explicitly re-allow the committed example template
+!.env.example
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+.venv/
+venv/
+env/
+*.egg-info/
+dist/
+build/
+.pytest_cache/
+
+# Virtual envs
+.python-version
+
+# Logs
+*.log
+logs/
+
+# macOS
+.DS_Store
+.AppleDouble
+
+# Editor artifacts
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Docker generated state (not committed; managed via docker-compose volumes)
+# If you add local bind-mounts for lakeFS data, exclude them here:
+# data/
+
+# Generated demo output
+output/
+tmp/

--- a/01_standalone_examples/lakefs-onebucket/Makefile
+++ b/01_standalone_examples/lakefs-onebucket/Makefile
@@ -43,13 +43,7 @@ up: _require-env
 	@echo "    When healthy:  make init"
 
 init: _require-env
-	@# Bootstrap the lakeFS admin user on first run via the built-in CLI.
-	@# Safe to re-run — lakeFS exits non-zero if already set up, which we suppress.
-	@$(COMPOSE) exec -T lakefs /app/lakefs setup \
-	  --user-name admin \
-	  --access-key-id "$$(grep '^LAKEFS_ACCESS_KEY_ID=' .env | cut -d= -f2)" \
-	  --secret-access-key "$$(grep '^LAKEFS_SECRET_ACCESS_KEY=' .env | cut -d= -f2)" \
-	  2>&1 | grep -vE "level=(info|warning)" || true
+	@# The admin user is created by the lakefs container itself (see docker-compose.yml).
 	$(PYTHON) scripts/init_lakefs.py
 
 demo: _require-env

--- a/01_standalone_examples/lakefs-onebucket/Makefile
+++ b/01_standalone_examples/lakefs-onebucket/Makefile
@@ -1,0 +1,74 @@
+PYTHON  := .venv/bin/python
+PIP     := .venv/bin/pip
+COMPOSE := docker compose
+
+.PHONY: help setup check-onebucket up init demo logs down clean
+
+help:
+	@echo "lakeFS + OneBucket demo"
+	@echo ""
+	@echo "Typical flow:"
+	@echo "  make setup            Install Python dependencies into .venv"
+	@echo "  make check-onebucket  Validate OneBucket endpoint/credentials/bucket"
+	@echo "  make up               Start lakeFS + Postgres in Docker"
+	@echo "  make init             Create (or validate) the lakeFS repository"
+	@echo "  make demo             Run the full demo workflow"
+	@echo "  make logs             Stream container logs (Ctrl-C to stop)"
+	@echo "  make down             Stop containers"
+	@echo "  make clean            Stop containers, remove volumes and .venv"
+	@echo ""
+	@echo "Repo modes (set in .env):"
+	@echo "  CREATE_LAKEFS_REPO=true   make init creates the repo (default)"
+	@echo "  CREATE_LAKEFS_REPO=false  make init validates an existing repo"
+
+setup:
+	@echo "==> Creating Python virtual environment..."
+	python3 -m venv .venv
+	$(PIP) install --upgrade pip --quiet
+	$(PIP) install -r requirements.txt
+	@echo ""
+	@echo "==> Done. Next steps:"
+	@echo "    1. cp .env.example .env"
+	@echo "    2. Edit .env with your OneBucket credentials"
+	@echo "    3. make check-onebucket"
+
+check-onebucket: _require-env
+	$(PYTHON) scripts/check_onebucket.py
+
+up: _require-env
+	$(COMPOSE) up -d
+	@echo ""
+	@echo "==> lakeFS starting on http://localhost:8000"
+	@echo "    Watch startup: make logs"
+	@echo "    When healthy:  make init"
+
+init: _require-env
+	@# Bootstrap the lakeFS admin user on first run via the built-in CLI.
+	@# Safe to re-run — lakeFS exits non-zero if already set up, which we suppress.
+	@$(COMPOSE) exec -T lakefs /app/lakefs setup \
+	  --user-name admin \
+	  --access-key-id "$$(grep '^LAKEFS_ACCESS_KEY_ID=' .env | cut -d= -f2)" \
+	  --secret-access-key "$$(grep '^LAKEFS_SECRET_ACCESS_KEY=' .env | cut -d= -f2)" \
+	  2>&1 | grep -vE "level=(info|warning)" || true
+	$(PYTHON) scripts/init_lakefs.py
+
+demo: _require-env
+	$(PYTHON) scripts/run_demo.py
+
+logs:
+	$(COMPOSE) logs -f
+
+down:
+	$(COMPOSE) down
+
+clean:
+	$(COMPOSE) down -v
+	rm -rf .venv
+	find . -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null; true
+	find . -name "*.pyc" -delete 2>/dev/null; true
+	find . -name ".DS_Store" -delete 2>/dev/null; true
+	@echo "==> Cleaned."
+
+# Internal guard — fails fast if .env is missing
+_require-env:
+	@test -f .env || (echo "ERROR: .env not found.\n  Run: cp .env.example .env  then edit it." && exit 1)

--- a/01_standalone_examples/lakefs-onebucket/README.md
+++ b/01_standalone_examples/lakefs-onebucket/README.md
@@ -186,8 +186,9 @@ This starts two containers:
 - **postgres** — lakeFS metadata store
 - **lakefs** — lakeFS server (API + S3 Gateway), mapped to `http://localhost:8000`
 
-On first start, lakeFS automatically creates the admin user using the
-`LAKEFS_ACCESS_KEY_ID` and `LAKEFS_SECRET_ACCESS_KEY` from your `.env`.
+On first start, the lakeFS container runs `lakefs setup` automatically, creating the
+admin user from the `LAKEFS_ACCESS_KEY_ID` and `LAKEFS_SECRET_ACCESS_KEY` in your `.env`.
+Later starts detect that setup is already complete and skip it.
 
 Watch startup logs: `make logs`
 

--- a/01_standalone_examples/lakefs-onebucket/README.md
+++ b/01_standalone_examples/lakefs-onebucket/README.md
@@ -1,0 +1,389 @@
+# lakeFS + OneBucket demo
+
+A reproducible local demo that runs lakeFS end-to-end against
+[OneBucket by Attimis](https://onebucket.io) as its S3-compatible blockstore.
+
+lakeFS runs locally in Docker (with PostgreSQL as its metadata store) and writes all
+of its blockstore objects to OneBucket over the S3 API. The same configuration applies
+to any S3-compatible object store — OneBucket is the one exercised here.
+
+> **Security note:** Never commit `.env`. It is in `.gitignore`. Only `.env.example`
+> (which contains placeholder values) is committed.
+
+---
+
+## What this demo proves
+
+```
+Client scripts → lakeFS API/S3 Gateway → lakeFS metadata (Postgres) + OneBucket blockstore
+```
+
+- **All demo data flows through lakeFS**, not directly to OneBucket.
+- lakeFS stores its data blocks and metadata manifests in OneBucket automatically.
+- The demo exercises branch, commit, and (optionally) merge — the core lakeFS versioning
+  primitives — while the underlying storage is OneBucket.
+
+---
+
+## Architecture
+
+```mermaid
+flowchart LR
+    subgraph scripts ["Local Scripts"]
+        demo["run_demo.py\n(boto3 + requests)"]
+        init["init_lakefs.py\n(requests)"]
+        check["check_onebucket.py\n(boto3 direct)"]
+    end
+
+    subgraph compose ["Docker Compose"]
+        lakefs["lakeFS :8000\n(API + S3 Gateway)"]
+        pg[("PostgreSQL\n(metadata)")]
+    end
+
+    subgraph ob ["OneBucket"]
+        bucket["S3-compatible\nBlockstore"]
+    end
+
+    demo -- "S3 Gateway\nPUT / GET / LIST" --> lakefs
+    demo -- "REST API\ncommit / branch / merge" --> lakefs
+    init -- "REST API" --> lakefs
+    lakefs --- pg
+    lakefs -- "S3 writes\n(blockstore)" --> bucket
+    check -. "Direct S3\n(validation only)" .-> bucket
+```
+
+`check_onebucket.py` is the **only** script that writes directly to OneBucket.
+It is a pre-flight connectivity check and cleans up after itself.
+
+---
+
+## Prerequisites
+
+| Tool | Version |
+|---|---|
+| Docker + Docker Compose | any recent |
+| Python | 3.11+ |
+| `make` | any |
+
+You will need:
+- OneBucket S3-compatible endpoint URL (with `https://` or `http://`)
+- OneBucket access key and secret key
+- An existing OneBucket bucket
+- (Optional) region string — `us-east-1` works for most S3-compatible endpoints
+
+---
+
+## Quick start
+
+```bash
+git clone https://github.com/treeverse/lakeFS-samples.git
+cd lakeFS-samples/01_standalone_examples/lakefs-onebucket
+cp .env.example .env
+# edit .env  ← fill in your OneBucket credentials
+make setup
+make check-onebucket
+make up
+make init
+make demo
+```
+
+---
+
+## Step-by-step setup
+
+### 1. Clone and copy the env file
+
+```bash
+cp .env.example .env
+```
+
+**Never commit `.env`** — it is excluded by `.gitignore`.
+
+### 2. Configure OneBucket credentials
+
+Open `.env` and fill in the OneBucket section:
+
+```dotenv
+ONEBUCKET_ENDPOINT=https://your-onebucket-endpoint.example.com
+ONEBUCKET_ACCESS_KEY_ID=your-access-key
+ONEBUCKET_SECRET_ACCESS_KEY=your-secret-key
+ONEBUCKET_BUCKET=your-bucket-name
+ONEBUCKET_REGION=us-east-1
+ONEBUCKET_FORCE_PATH_STYLE=true     # keep true — required for most S3-compatible stores
+ONEBUCKET_SKIP_VERIFY=false         # set true if OneBucket uses a self-signed cert
+```
+
+> **Important:** Put only the hostname (and port if needed) in `ONEBUCKET_ENDPOINT`.
+> Do not include the bucket name in the endpoint URL.
+
+### 3. Configure lakeFS credentials
+
+Still in `.env`, set the lakeFS admin credentials. These will be created automatically
+on first container start. Choose any non-empty values:
+
+```dotenv
+LAKEFS_ACCESS_KEY_ID=your-lakefs-admin-key
+LAKEFS_SECRET_ACCESS_KEY=your-lakefs-admin-secret
+```
+
+Generate the required secret keys:
+
+```bash
+openssl rand -hex 32   # use the output for LAKEFS_AUTH_ENCRYPT_SECRET_KEY
+openssl rand -hex 32   # use the output for LAKEFS_BLOCKSTORE_SIGNING_SECRET_KEY
+```
+
+### 4. Choose the storage namespace
+
+`LAKEFS_STORAGE_NAMESPACE` controls where lakeFS writes its blockstore objects inside
+the OneBucket bucket. It must start with `s3://`.
+
+You can use any valid path:
+
+```dotenv
+# Recommended: use a prefix to isolate lakeFS data
+LAKEFS_STORAGE_NAMESPACE=s3://my-bucket/lakefs/onebucket-demo/
+
+# Other valid options:
+# LAKEFS_STORAGE_NAMESPACE=s3://my-bucket/
+# LAKEFS_STORAGE_NAMESPACE=s3://my-bucket/demos/experiment1/
+```
+
+If `LAKEFS_STORAGE_NAMESPACE` is empty, `make init` derives a safe default:
+```
+s3://<ONEBUCKET_BUCKET>/lakefs/<LAKEFS_REPO>/
+```
+
+### 5. Install Python dependencies
+
+```bash
+make setup
+```
+
+This creates `.venv/` and installs `requirements.txt`.
+
+### 6. Validate OneBucket connectivity
+
+```bash
+make check-onebucket
+```
+
+This runs `scripts/check_onebucket.py`, which:
+- Validates endpoint format and credentials
+- Does a HeadBucket to confirm bucket access
+- Writes, reads, and deletes a test object under `_lakefs_demo_connectivity_check/`
+- Prints actionable diagnostics if anything fails
+
+Fix any errors before proceeding. See [docs/troubleshooting.md](docs/troubleshooting.md).
+
+### 7. Start lakeFS
+
+```bash
+make up
+```
+
+This starts two containers:
+- **postgres** — lakeFS metadata store
+- **lakefs** — lakeFS server (API + S3 Gateway), mapped to `http://localhost:8000`
+
+On first start, lakeFS automatically creates the admin user using the
+`LAKEFS_ACCESS_KEY_ID` and `LAKEFS_SECRET_ACCESS_KEY` from your `.env`.
+
+Watch startup logs: `make logs`
+
+The lakeFS UI is at **http://localhost:8000** when ready.
+
+### 8. Initialize the lakeFS repository
+
+```bash
+make init
+```
+
+This runs `scripts/init_lakefs.py`, which:
+- Waits for lakeFS to be healthy and accepts authentication
+- Creates (or validates) the repository
+
+**Auto-create mode** (default, `CREATE_LAKEFS_REPO=true`):
+- Creates the repository named `LAKEFS_REPO` with storage namespace `LAKEFS_STORAGE_NAMESPACE`
+- Idempotent — safe to re-run; skips creation if the repository already exists
+
+**Existing-repo mode** (`CREATE_LAKEFS_REPO=false`):
+- Does **not** create a repository
+- Validates that `LAKEFS_REPO` exists in lakeFS
+- Prints the detected repository info (name, storage namespace, default branch)
+- Use this when you have created a repository manually via the UI or API
+
+### 9. Run the demo
+
+```bash
+make demo
+```
+
+This runs `scripts/run_demo.py`, which uses **boto3 pointed at the lakeFS S3 Gateway**
+(not directly at OneBucket) to demonstrate:
+
+1. Upload `raw/customers.csv` to the `main` branch via lakeFS
+2. Commit on `main`
+3. Create an `experiment` branch
+4. Upload `processed/customers_clean.csv` to `experiment` via lakeFS
+5. Commit on `experiment`
+6. *(Optional)* Merge `experiment` → `main` (set `MERGE_EXPERIMENT=true` in `.env`)
+7. List objects on both branches
+8. Read objects back
+
+---
+
+## Expected output
+
+```
+============================================================
+  lakeFS + OneBucket demo
+============================================================
+  lakeFS endpoint:  http://localhost:8000
+  Repository:       onebucket-demo
+  Main branch:      main
+  Merge experiment: false
+============================================================
+
+------------------------------------------------------------
+[1] Writing object through lakeFS S3 Gateway:
+    Bucket: onebucket-demo  Key: main/raw/customers.csv
+    OK
+------------------------------------------------------------
+[2] Committing to 'main'...
+    Commit ID: <commit-id>
+------------------------------------------------------------
+[3] Creating branch 'experiment' from 'main'...
+    OK
+------------------------------------------------------------
+[4] Writing transformed object through lakeFS S3 Gateway:
+    Bucket: onebucket-demo  Key: experiment/processed/customers_clean.csv
+    OK
+------------------------------------------------------------
+[5] Committing to 'experiment'...
+    Commit ID: <commit-id>
+------------------------------------------------------------
+[6] Skipping merge (set MERGE_EXPERIMENT=true in .env to enable)
+------------------------------------------------------------
+[7] Objects on 'main':
+    raw/customers.csv
+
+    Objects on 'experiment':
+    raw/customers.csv
+    processed/customers_clean.csv
+------------------------------------------------------------
+[8] Reading objects back...
+    main/raw/customers.csv: 121 bytes — OK
+    experiment/processed/customers_clean.csv: 110 bytes — OK
+------------------------------------------------------------
+
+============================================================
+  Demo Summary
+============================================================
+  Repository:            onebucket-demo
+  Main commit:           <commit-id>
+  Experiment commit:     <commit-id>
+  Objects on main:       1
+  Objects on experiment: 2
+
+  Demo completed successfully.
+
+  lakeFS UI: http://localhost:8000/repositories/onebucket-demo/objects
+============================================================
+```
+
+---
+
+## Cleanup
+
+Stop containers (preserve volumes and credentials):
+```bash
+make down
+```
+
+Full cleanup — stops containers, removes Docker volumes (Postgres data), and deletes `.venv`:
+```bash
+make clean
+```
+
+> `make clean` does **not** delete `.env` or anything in OneBucket.
+> lakeFS blockstore objects in OneBucket must be cleaned up manually (or by deleting the
+> bucket prefix defined in `LAKEFS_STORAGE_NAMESPACE`).
+
+---
+
+## Repository modes reference
+
+| `.env` setting | `make init` behavior |
+|---|---|
+| `CREATE_LAKEFS_REPO=true` | Creates `LAKEFS_REPO` using `LAKEFS_STORAGE_NAMESPACE`. Idempotent. |
+| `CREATE_LAKEFS_REPO=false` | Validates that `LAKEFS_REPO` exists. Prints its info. Fails if not found. |
+
+---
+
+## All Makefile targets
+
+| Target | Description |
+|---|---|
+| `make setup` | Create `.venv` and install Python dependencies |
+| `make check-onebucket` | Validate OneBucket endpoint/credentials/bucket |
+| `make up` | Start lakeFS + Postgres in Docker |
+| `make init` | Create or validate the lakeFS repository |
+| `make demo` | Run the full demo workflow |
+| `make logs` | Stream container logs (Ctrl-C to stop) |
+| `make down` | Stop containers |
+| `make clean` | Stop containers, remove volumes and `.venv` |
+
+---
+
+## Troubleshooting
+
+See [docs/troubleshooting.md](docs/troubleshooting.md) for common issues including:
+
+- TLS / self-signed certificate errors
+- Port conflicts
+- Authentication failures on first run
+- boto3 checksum errors against the lakeFS S3 Gateway
+- lakeFS blockstore write failures
+
+---
+
+## Configuring lakeFS against an S3-compatible store
+
+See [docs/onebucket-notes.md](docs/onebucket-notes.md) for:
+
+- Why path-style addressing is required
+- TLS verification configuration
+- Region handling for S3-compatible endpoints
+- What lakeFS writes to the bucket (data blocks + metadata manifests)
+
+### Key configuration decisions
+
+| Setting | Value | Reason |
+|---|---|---|
+| `ONEBUCKET_FORCE_PATH_STYLE` | `true` | Required for S3-compatible stores without DNS wildcards |
+| `LAKEFS_BLOCKSTORE_S3_STREAMINGCHUNKEDENCODING` | `false` | Some S3-compatible APIs reject AWS chunked encoding |
+| boto3 checksum mode | `when_required` | Avoids checksum header conflicts with lakeFS S3 Gateway |
+| lakeFS metadata | Postgres | More realistic than embedded; matches production deployments |
+
+---
+
+## File layout
+
+```
+.
+├── .env.example              # Credential template — fill in and save as .env
+├── .env                      # Your credentials — gitignored, never commit
+├── .gitignore
+├── Makefile
+├── README.md
+├── docker-compose.yml        # lakeFS + Postgres; reads credentials from .env
+├── requirements.txt
+├── scripts/
+│   ├── check_onebucket.py    # Direct OneBucket connectivity validation
+│   ├── init_lakefs.py        # lakeFS repository bootstrap / validation
+│   └── run_demo.py           # Full demo workflow via lakeFS
+└── docs/
+    ├── troubleshooting.md
+    └── onebucket-notes.md
+```

--- a/01_standalone_examples/lakefs-onebucket/docker-compose.yml
+++ b/01_standalone_examples/lakefs-onebucket/docker-compose.yml
@@ -1,0 +1,89 @@
+# Docker Compose reads .env automatically for variable substitution.
+# All secrets come from .env — nothing is hardcoded here.
+
+services:
+
+  # ── Metadata store ────────────────────────────────────────────────────────
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-lakefs}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-lakefs}
+      POSTGRES_DB: ${POSTGRES_DB:-lakefs}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-lakefs} -d ${POSTGRES_DB:-lakefs}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  # ── lakeFS ───────────────────────────────────────────────────────────────
+  lakefs:
+    image: treeverse/lakefs:latest
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      # host:container — lakeFS listens on 8000 inside the container by default
+      - "8000:8000"
+    environment:
+
+      # ── Database ──────────────────────────────────────────────────────────
+      LAKEFS_DATABASE_TYPE: postgres
+      LAKEFS_DATABASE_POSTGRES_CONNECTION_STRING: >-
+        postgresql://${POSTGRES_USER:-lakefs}:${POSTGRES_PASSWORD:-lakefs}@postgres:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-lakefs}?sslmode=disable
+
+      # ── Auth encryption ────────────────────────────────────────────────────
+      # Required. Generate with: openssl rand -hex 32
+      LAKEFS_AUTH_ENCRYPT_SECRET_KEY: ${LAKEFS_AUTH_ENCRYPT_SECRET_KEY}
+
+      # ── Blockstore: S3-compatible (OneBucket) ─────────────────────────────
+      LAKEFS_BLOCKSTORE_TYPE: s3
+
+      # The OneBucket S3-compatible endpoint (must include scheme).
+      LAKEFS_BLOCKSTORE_S3_ENDPOINT: ${ONEBUCKET_ENDPOINT}
+      # Disable auto region discovery and use LAKEFS_BLOCKSTORE_S3_REGION below.
+      # Region discovery relies on GetBucketLocation, which S3-compatible
+      # endpoints do not always implement.
+      LAKEFS_BLOCKSTORE_S3_DISCOVER_BUCKET_REGION: "false"
+
+      LAKEFS_BLOCKSTORE_S3_REGION: ${ONEBUCKET_REGION:-us-east-1}
+
+      # Static credentials for lakeFS to authenticate with OneBucket.
+      LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_KEY_ID: ${ONEBUCKET_ACCESS_KEY_ID}
+      LAKEFS_BLOCKSTORE_S3_CREDENTIALS_SECRET_ACCESS_KEY: ${ONEBUCKET_SECRET_ACCESS_KEY}
+
+      # Path-style addressing: required by most S3-compatible stores including OneBucket.
+      LAKEFS_BLOCKSTORE_S3_FORCE_PATH_STYLE: ${ONEBUCKET_FORCE_PATH_STYLE:-true}
+
+      # Set to true if OneBucket uses a self-signed or private CA certificate.
+      LAKEFS_BLOCKSTORE_S3_SKIP_VERIFY_HTTPS: ${ONEBUCKET_SKIP_VERIFY:-false}
+
+      # Disable chunked transfer encoding — some S3-compatible APIs reject it.
+      LAKEFS_BLOCKSTORE_S3_STREAMINGCHUNKEDENCODING: "false"
+
+      # ── S3 pre-signed URL signing ─────────────────────────────────────────
+      # Required for lakeFS to sign pre-signed URLs via its gateway.
+      LAKEFS_BLOCKSTORE_SIGNING_SECRET_KEY: ${LAKEFS_BLOCKSTORE_SIGNING_SECRET_KEY}
+
+      # ── Initial admin user (first-run bootstrap) ──────────────────────────
+      # These values are consumed ONLY on the very first start to create the
+      # admin user and complete the setup wizard automatically.
+      # On subsequent starts they are silently ignored.
+      LAKEFS_INSTALLATION_USER_NAME: admin
+      LAKEFS_INSTALLATION_ACCESS_KEY_ID: ${LAKEFS_ACCESS_KEY_ID}
+      LAKEFS_INSTALLATION_SECRET_ACCESS_KEY: ${LAKEFS_SECRET_ACCESS_KEY}
+
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8000/_health >/dev/null 2>&1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+
+volumes:
+  postgres_data:

--- a/01_standalone_examples/lakefs-onebucket/docker-compose.yml
+++ b/01_standalone_examples/lakefs-onebucket/docker-compose.yml
@@ -74,9 +74,14 @@ services:
       # These values are consumed ONLY on the very first start to create the
       # admin user and complete the setup wizard automatically.
       # On subsequent starts they are silently ignored.
-      LAKEFS_INSTALLATION_USER_NAME: admin
-      LAKEFS_INSTALLATION_ACCESS_KEY_ID: ${LAKEFS_ACCESS_KEY_ID}
-      LAKEFS_INSTALLATION_SECRET_ACCESS_KEY: ${LAKEFS_SECRET_ACCESS_KEY}
+      LAKECTL_CREDENTIALS_ACCESS_KEY_ID: ${LAKEFS_ACCESS_KEY_ID}
+      LAKECTL_CREDENTIALS_SECRET_ACCESS_KEY: ${LAKEFS_SECRET_ACCESS_KEY}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+        - |
+          lakefs setup --user-name admin --access-key-id "$$LAKECTL_CREDENTIALS_ACCESS_KEY_ID" --secret-access-key "$$LAKECTL_CREDENTIALS_SECRET_ACCESS_KEY" || true
+          lakefs run &
+          wait
 
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8000/_health >/dev/null 2>&1"]

--- a/01_standalone_examples/lakefs-onebucket/docker-compose.yml
+++ b/01_standalone_examples/lakefs-onebucket/docker-compose.yml
@@ -70,18 +70,26 @@ services:
       # Required for lakeFS to sign pre-signed URLs via its gateway.
       LAKEFS_BLOCKSTORE_SIGNING_SECRET_KEY: ${LAKEFS_BLOCKSTORE_SIGNING_SECRET_KEY}
 
-      # ── Initial admin user (first-run bootstrap) ──────────────────────────
-      # These values are consumed ONLY on the very first start to create the
-      # admin user and complete the setup wizard automatically.
-      # On subsequent starts they are silently ignored.
-      LAKECTL_CREDENTIALS_ACCESS_KEY_ID: ${LAKEFS_ACCESS_KEY_ID}
-      LAKECTL_CREDENTIALS_SECRET_ACCESS_KEY: ${LAKEFS_SECRET_ACCESS_KEY}
+      # ── Initial admin user (bootstrap) ────────────────────────────────────
+      # Passed to `lakefs setup` in the command below. Deliberately NOT named
+      # LAKEFS_INSTALLATION_*: those are only honoured when
+      # LAKEFS_DATABASE_TYPE=local, so they do nothing on a postgres install.
+      # See docs/troubleshooting.md.
+      SETUP_ADMIN_ACCESS_KEY_ID: ${LAKEFS_ACCESS_KEY_ID}
+      SETUP_ADMIN_SECRET_ACCESS_KEY: ${LAKEFS_SECRET_ACCESS_KEY}
+
+    # Run setup before starting the server. `setup` is idempotent: on every
+    # start after the first it exits non-zero with "Setup is already
+    # complete.", which `|| true` absorbs.
+    #
+    # `exec` replaces the shell with lakeFS so it becomes PID 1 and receives
+    # SIGTERM directly — without it, `docker compose stop` kills the shell and
+    # lakeFS is SIGKILLed (exit 137) instead of shutting down cleanly.
     entrypoint: ["/bin/sh", "-c"]
     command:
         - |
-          lakefs setup --user-name admin --access-key-id "$$LAKECTL_CREDENTIALS_ACCESS_KEY_ID" --secret-access-key "$$LAKECTL_CREDENTIALS_SECRET_ACCESS_KEY" || true
-          lakefs run &
-          wait
+          lakefs setup --user-name admin --access-key-id "$$SETUP_ADMIN_ACCESS_KEY_ID" --secret-access-key "$$SETUP_ADMIN_SECRET_ACCESS_KEY" || true
+          exec lakefs run
 
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8000/_health >/dev/null 2>&1"]

--- a/01_standalone_examples/lakefs-onebucket/docs/onebucket-notes.md
+++ b/01_standalone_examples/lakefs-onebucket/docs/onebucket-notes.md
@@ -1,0 +1,130 @@
+# Configuration notes: lakeFS on an S3-compatible blockstore
+
+This demo points lakeFS at OneBucket over the S3 API. The settings below are what make
+that work, and why. They apply to most S3-compatible object stores, not just OneBucket.
+
+---
+
+## Path-style addressing
+
+Set `ONEBUCKET_FORCE_PATH_STYLE=true` (the default in `.env.example`).
+
+Virtual-hosted-style addressing (`bucket.endpoint/key`) requires DNS wildcard entries
+that many S3-compatible deployments do not have. Path-style (`endpoint/bucket/key`) is
+broadly supported.
+
+In `docker-compose.yml` this maps to:
+```
+LAKEFS_BLOCKSTORE_S3_FORCE_PATH_STYLE: true
+```
+
+In the boto3 clients (both `check_onebucket.py` and `run_demo.py`):
+```python
+Config(s3={"addressing_style": "path"})
+```
+
+---
+
+## TLS / self-signed certificates
+
+If your endpoint uses a self-signed or private CA certificate:
+- Set `ONEBUCKET_SKIP_VERIFY=true` in `.env`.
+- This propagates to:
+  - `LAKEFS_BLOCKSTORE_S3_SKIP_VERIFY_HTTPS=true` in the lakeFS container.
+  - `verify=False` in the boto3 client in `check_onebucket.py`.
+
+> This is a convenience for local demos. For production, configure a proper certificate
+> chain rather than disabling verification.
+
+---
+
+## Region
+
+Many S3-compatible endpoints accept any region string. The default `us-east-1` usually
+works. If your endpoint requires a specific region, set `ONEBUCKET_REGION=<region>` in
+`.env` — it flows to both `LAKEFS_BLOCKSTORE_S3_REGION` and the boto3 session region.
+
+This demo also sets:
+```
+LAKEFS_BLOCKSTORE_S3_DISCOVER_BUCKET_REGION: "false"
+```
+
+Automatic region discovery calls `GetBucketLocation`, which S3-compatible endpoints do
+not always implement. Setting the region explicitly and disabling discovery avoids
+depending on it.
+
+---
+
+## Chunked/streaming transfer encoding
+
+Some S3-compatible APIs do not accept AWS Signature V4 chunked (streaming) encoding.
+`docker-compose.yml` disables it for lakeFS:
+```
+LAKEFS_BLOCKSTORE_S3_STREAMINGCHUNKEDENCODING: "false"
+```
+
+The boto3 clients in `check_onebucket.py` and `run_demo.py` also disable automatic
+checksum negotiation for the same reason:
+```python
+request_checksum_calculation="when_required",
+response_checksum_validation="when_required",
+```
+
+---
+
+## Storage namespace layout
+
+lakeFS writes all of its blockstore objects (data blocks + metadata manifests) under
+`LAKEFS_STORAGE_NAMESPACE`.
+
+Recommended layout for multiple demos or repositories:
+```
+s3://my-bucket/lakefs/
+  onebucket-demo/
+    data/
+    _lakefs/
+  other-repo/
+    ...
+```
+
+The default derived namespace is `s3://<ONEBUCKET_BUCKET>/lakefs/<LAKEFS_REPO>/`.
+Using a prefix keeps lakeFS objects from mixing with other bucket content and makes
+cleanup straightforward: delete the prefix.
+
+---
+
+## What lakeFS writes to the bucket
+
+lakeFS writes two categories of objects to the blockstore:
+
+1. **Data blocks** — content-addressable chunks of the files committed through lakeFS.
+   Written at commit time. Path example: `<namespace>/data/<id>`.
+
+2. **Metadata** — range and meta-range files encoding the committed tree.
+   Path example: `<namespace>/_lakefs/`.
+
+`run_demo.py` does **not** write directly to the object store. All data flows through
+the lakeFS S3 Gateway, which manages the blockstore writes internally.
+
+---
+
+## Connectivity check prefix
+
+`check_onebucket.py` writes and deletes a single test object under:
+```
+_lakefs_demo_connectivity_check/
+```
+
+This is the only script that talks directly to the object store. It is safe to re-run;
+it cleans up after itself.
+
+---
+
+## If something behaves unexpectedly
+
+lakeFS needs a fairly small slice of the S3 API. If a call fails, check
+`docker compose logs lakefs` and confirm the credentials have `s3:GetObject`,
+`s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket`, and multipart upload permissions on
+the bucket. Bucket versioning is not required — lakeFS manages its own versioning layer.
+
+See [troubleshooting.md](troubleshooting.md) for specific errors and fixes.

--- a/01_standalone_examples/lakefs-onebucket/docs/troubleshooting.md
+++ b/01_standalone_examples/lakefs-onebucket/docs/troubleshooting.md
@@ -65,11 +65,13 @@ This sets `LAKEFS_BLOCKSTORE_S3_SKIP_VERIFY_HTTPS=true` in the lakeFS container 
 
 ## `make init` fails with authentication error after lakeFS starts
 
-`make init` bootstraps the admin user by running `lakefs setup` inside the container
-before calling the Python init script. If authentication still fails:
+The lakeFS container bootstraps the admin user by running `lakefs setup` before
+starting the server (see the `command:` block in `docker-compose.yml`). If
+authentication still fails:
 
 - Verify `LAKEFS_ACCESS_KEY_ID` and `LAKEFS_SECRET_ACCESS_KEY` are set in `.env`.
-- Check whether `lakefs setup` reported an error:
+- Check whether setup reported an error: `docker compose logs lakefs | head -40`
+- Re-run setup by hand:
   ```bash
   docker compose exec lakefs /app/lakefs setup \
     --user-name admin \
@@ -79,10 +81,33 @@ before calling the Python init script. If authentication still fails:
 - If lakeFS was previously initialised with different credentials (stale Postgres volume),
   do a full reset: `make clean && make up && make init`
 
-**Note on `LAKEFS_INSTALLATION_*` env vars:** these are read by lakeFS at startup but only
-trigger auto-setup on a completely empty database. If the database was previously
-initialised (even without completing setup), they are silently skipped. `make init` uses
-`lakefs setup` via docker exec instead, which is reliable regardless of database state.
+**Why not `LAKEFS_INSTALLATION_*`?** Those variables only trigger auto-setup when
+`LAKEFS_DATABASE_TYPE=local`. This example runs on PostgreSQL, where they are ignored
+entirely — so the container calls `lakefs setup` explicitly instead.
+
+---
+
+## `make init` fails with "storage namespace already in use"
+
+```
+failed to create repository: found lakeFS objects in the storage
+namespace(s3://your-bucket/your-prefix/) key(_lakefs/dummy): storage namespace already in use
+```
+
+lakeFS refuses to create a repository over a prefix that already holds lakeFS data.
+This usually means the repository was created before and its metadata is still in
+OneBucket — most often after `make clean`, which removes the PostgreSQL volume but
+does **not** touch the bucket.
+
+Pick one:
+
+- **Point at a fresh prefix** — change `LAKEFS_STORAGE_NAMESPACE` in `.env`
+  (for example `s3://your-bucket/demo-2/`) and re-run `make init`.
+- **Reuse the existing repository** — if the repo still exists in lakeFS, set
+  `CREATE_LAKEFS_REPO=false` in `.env` and `make init` will validate it instead
+  of creating it.
+- **Clear the prefix** — delete the objects under that namespace in OneBucket,
+  then re-run `make init`. This permanently destroys the repository's data.
 
 ---
 

--- a/01_standalone_examples/lakefs-onebucket/docs/troubleshooting.md
+++ b/01_standalone_examples/lakefs-onebucket/docs/troubleshooting.md
@@ -1,0 +1,143 @@
+# Troubleshooting
+
+## lakeFS container exits immediately
+
+**Check logs:**
+```bash
+docker compose logs lakefs
+```
+
+Common causes:
+- `LAKEFS_AUTH_ENCRYPT_SECRET_KEY` is empty — generate one: `openssl rand -hex 32`
+- `ONEBUCKET_ENDPOINT` is missing or malformed (must include `http://` or `https://`)
+- Postgres not yet ready — lakeFS depends on the postgres healthcheck, but Docker Compose
+  health propagation can occasionally race. Try `make down && make up`.
+
+---
+
+## `make check-onebucket` fails with TLS error
+
+Set in `.env`:
+```
+ONEBUCKET_SKIP_VERIFY=true
+```
+This sets `LAKEFS_BLOCKSTORE_S3_SKIP_VERIFY_HTTPS=true` in the lakeFS container and
+`verify=False` in the Python boto3 client.
+
+> Only use this if OneBucket uses a self-signed or private CA certificate.
+
+---
+
+## `make check-onebucket` fails with "Connection refused" or "Cannot resolve hostname"
+
+- Verify `ONEBUCKET_ENDPOINT` is reachable from your machine (not just inside Docker).
+- If the endpoint is only accessible from inside Docker, run the check inside a container:
+  ```bash
+  docker compose run --rm lakefs wget -qO- ${ONEBUCKET_ENDPOINT} || true
+  ```
+- Ensure the URL scheme is present: `https://...` not `example.onebucket.endpoint`.
+
+---
+
+## `make check-onebucket` fails with "Bucket does not exist" (404)
+
+- Check `ONEBUCKET_BUCKET` — make sure the bucket name is correct and does not include
+  a path or the endpoint hostname.
+- Verify the bucket exists in OneBucket.
+
+---
+
+## `make check-onebucket` fails with "Access denied" (403)
+
+- Credentials lack permission on the bucket. Verify in OneBucket that the key has at
+  minimum: `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket`,
+  `s3:HeadBucket`.
+
+---
+
+## `make init` times out waiting for lakeFS
+
+- Check that `make up` completed: `docker compose ps`
+- Watch startup: `make logs`
+- The lakeFS container may be crashing — check: `docker compose logs lakefs`
+
+---
+
+## `make init` fails with authentication error after lakeFS starts
+
+`make init` bootstraps the admin user by running `lakefs setup` inside the container
+before calling the Python init script. If authentication still fails:
+
+- Verify `LAKEFS_ACCESS_KEY_ID` and `LAKEFS_SECRET_ACCESS_KEY` are set in `.env`.
+- Check whether `lakefs setup` reported an error:
+  ```bash
+  docker compose exec lakefs /app/lakefs setup \
+    --user-name admin \
+    --access-key-id YOUR_KEY \
+    --secret-access-key YOUR_SECRET
+  ```
+- If lakeFS was previously initialised with different credentials (stale Postgres volume),
+  do a full reset: `make clean && make up && make init`
+
+**Note on `LAKEFS_INSTALLATION_*` env vars:** these are read by lakeFS at startup but only
+trigger auto-setup on a completely empty database. If the database was previously
+initialised (even without completing setup), they are silently skipped. `make init` uses
+`lakefs setup` via docker exec instead, which is reliable regardless of database state.
+
+---
+
+## `make demo` fails with `InvalidBucketName` or 400 error
+
+- The `LAKEFS_REPO` repository may not exist yet. Run `make init` first.
+- Ensure `LAKEFS_REPO` contains only lowercase letters, numbers, and hyphens.
+
+---
+
+## `make demo` fails with checksum-related errors on PutObject
+
+boto3 1.35+ sends `x-amz-checksum-*` headers that some lakeFS versions reject.
+The scripts already set:
+```python
+Config(
+    request_checksum_calculation="when_required",
+    response_checksum_validation="when_required",
+)
+```
+If you still see checksum errors, downgrade boto3: `pip install boto3==1.34.162`.
+
+---
+
+## lakeFS cannot write to OneBucket (blockstore errors)
+
+Check `docker compose logs lakefs` for errors like `failed to put object`.
+
+Common causes:
+- `ONEBUCKET_FORCE_PATH_STYLE=false` — set to `true` for most S3-compatible stores.
+- Chunked transfer encoding rejected — already disabled via
+  `LAKEFS_BLOCKSTORE_S3_STREAMINGCHUNKEDENCODING=false` in `docker-compose.yml`.
+- TLS verification failing inside the container — set `ONEBUCKET_SKIP_VERIFY=true`.
+- `ONEBUCKET_REGION` mismatch — try `us-east-1` or whatever the endpoint expects.
+
+---
+
+## Objects visible in lakeFS but missing in OneBucket
+
+lakeFS writes blockstore objects under the path set in `LAKEFS_STORAGE_NAMESPACE`.
+Check inside OneBucket that objects exist under that prefix.
+
+---
+
+## `make clean` warning: volumes still in use
+
+Stop all containers first: `docker compose down`, then `make clean`.
+
+---
+
+## Port 8000 already in use
+
+Change the host port in `docker-compose.yml`:
+```yaml
+ports:
+  - "8001:8080"
+```
+Then update `LAKEFS_ENDPOINT=http://localhost:8001` in `.env`.

--- a/01_standalone_examples/lakefs-onebucket/requirements.txt
+++ b/01_standalone_examples/lakefs-onebucket/requirements.txt
@@ -1,0 +1,4 @@
+boto3>=1.35.0
+botocore>=1.35.0
+requests>=2.31.0
+python-dotenv>=1.0.0

--- a/01_standalone_examples/lakefs-onebucket/scripts/check_onebucket.py
+++ b/01_standalone_examples/lakefs-onebucket/scripts/check_onebucket.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+Validate OneBucket connectivity before starting lakeFS.
+
+Performs a safe write/read/delete under the prefix:
+  _lakefs_demo_connectivity_check/
+
+Nothing outside that prefix is touched.
+"""
+
+import os
+import sys
+import urllib.parse
+from pathlib import Path
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+from dotenv import load_dotenv
+
+# Load .env from the project root (one level up from scripts/)
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+TEST_PREFIX = "_lakefs_demo_connectivity_check/"
+TEST_KEY = f"{TEST_PREFIX}test.txt"
+TEST_BODY = b"lakeFS OneBucket connectivity check"
+
+
+def redact(value: str) -> str:
+    if not value:
+        return "(empty)"
+    if len(value) <= 8:
+        return "***"
+    return value[:4] + "***" + value[-2:]
+
+
+def validate_endpoint(raw: str) -> str:
+    endpoint = raw.strip()
+    if not endpoint:
+        raise ValueError("ONEBUCKET_ENDPOINT is not set")
+    if not endpoint.startswith(("http://", "https://")):
+        raise ValueError(
+            f"ONEBUCKET_ENDPOINT must start with http:// or https://\n"
+            f"  Got: {endpoint!r}"
+        )
+    parsed = urllib.parse.urlparse(endpoint)
+    if parsed.path and parsed.path not in ("/", ""):
+        # Bucket name accidentally included in endpoint URL is a common mistake
+        print(
+            f"  WARNING: ONEBUCKET_ENDPOINT contains a path '{parsed.path}'.\n"
+            "           The bucket name belongs in ONEBUCKET_BUCKET, not the endpoint URL."
+        )
+    return endpoint
+
+
+def make_s3_client(
+    endpoint: str,
+    access_key: str,
+    secret_key: str,
+    region: str,
+    force_path_style: bool,
+    skip_verify: bool,
+) -> boto3.client:
+    if skip_verify:
+        # Suppress InsecureRequestWarning when TLS verification is disabled
+        import urllib3
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    session = boto3.Session(
+        aws_access_key_id=access_key.strip(),
+        aws_secret_access_key=secret_key.strip(),
+        region_name=region.strip() or "us-east-1",
+    )
+    return session.client(
+        "s3",
+        endpoint_url=endpoint,
+        verify=not skip_verify,
+        config=Config(
+            s3={"addressing_style": "path" if force_path_style else "auto"},
+            # Avoid checksum negotiation issues with S3-compatible endpoints
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
+        ),
+    )
+
+
+def diagnose_connection_error(exc: Exception, endpoint: str, skip_verify: bool) -> None:
+    msg = str(exc).lower()
+    if "ssl" in msg or "certificate" in msg:
+        if not skip_verify:
+            print(f"  ERROR: TLS/SSL error connecting to {endpoint}")
+            print("         Set ONEBUCKET_SKIP_VERIFY=true in .env if OneBucket uses a")
+            print("         self-signed or private CA certificate.")
+        else:
+            print(f"  ERROR: SSL error even with verify disabled: {exc}")
+    elif "connection refused" in msg:
+        print(f"  ERROR: Connection refused at {endpoint}")
+        print("         Is the OneBucket endpoint reachable from this machine?")
+    elif "name or service not known" in msg or "nodename nor servname" in msg or "getaddrinfo" in msg:
+        print(f"  ERROR: Cannot resolve hostname in {endpoint}")
+        print("         Check ONEBUCKET_ENDPOINT and your DNS / network settings.")
+    elif "timed out" in msg or "timeout" in msg:
+        print(f"  ERROR: Connection timed out to {endpoint}")
+        print("         The endpoint may be unreachable or slow to respond.")
+    else:
+        print(f"  ERROR: {type(exc).__name__}: {exc}")
+
+
+def run_check() -> None:
+    print("=" * 60)
+    print("  OneBucket connectivity check")
+    print("=" * 60)
+
+    endpoint_raw = os.environ.get("ONEBUCKET_ENDPOINT", "")
+    access_key = os.environ.get("ONEBUCKET_ACCESS_KEY_ID", "")
+    secret_key = os.environ.get("ONEBUCKET_SECRET_ACCESS_KEY", "")
+    bucket = os.environ.get("ONEBUCKET_BUCKET", "")
+    region = os.environ.get("ONEBUCKET_REGION", "us-east-1")
+    force_path_style = os.environ.get("ONEBUCKET_FORCE_PATH_STYLE", "true").lower() == "true"
+    skip_verify = os.environ.get("ONEBUCKET_SKIP_VERIFY", "false").lower() == "true"
+
+    print(f"\n  Endpoint:         {endpoint_raw or '(not set)'}")
+    print(f"  Access key:       {redact(access_key)}")
+    print(f"  Secret key:       {redact(secret_key)}")
+    print(f"  Bucket:           {bucket or '(not set)'}")
+    print(f"  Region:           {region or '(not set)'}")
+    print(f"  Path-style:       {force_path_style}")
+    print(f"  Skip TLS verify:  {skip_verify}")
+    print()
+
+    # Validate required fields
+    errors: list[str] = []
+    if not access_key:
+        errors.append("ONEBUCKET_ACCESS_KEY_ID is not set")
+    elif access_key != access_key.strip():
+        errors.append("ONEBUCKET_ACCESS_KEY_ID has leading/trailing whitespace — check your .env")
+    if not secret_key:
+        errors.append("ONEBUCKET_SECRET_ACCESS_KEY is not set")
+    elif secret_key != secret_key.strip():
+        errors.append("ONEBUCKET_SECRET_ACCESS_KEY has leading/trailing whitespace — check your .env")
+    if not bucket:
+        errors.append("ONEBUCKET_BUCKET is not set")
+
+    try:
+        endpoint = validate_endpoint(endpoint_raw)
+    except ValueError as exc:
+        errors.append(str(exc))
+        endpoint = ""
+
+    if errors:
+        print("Configuration errors:")
+        for err in errors:
+            print(f"  ERROR: {err}")
+        sys.exit(1)
+
+    # Build client
+    print("Building S3 client...")
+    try:
+        client = make_s3_client(endpoint, access_key, secret_key, region, force_path_style, skip_verify)
+    except Exception as exc:
+        print(f"  ERROR: Failed to create S3 client: {exc}")
+        sys.exit(1)
+    print("  OK\n")
+
+    print(f"Testing bucket: s3://{bucket}/")
+
+    # 1. Head bucket
+    print("  [1/4] Checking bucket existence (HeadBucket)...")
+    try:
+        client.head_bucket(Bucket=bucket)
+        print("        OK")
+    except ClientError as exc:
+        code = exc.response["Error"]["Code"]
+        if code in ("403", "AccessDenied"):
+            print(f"        ERROR: Access denied to bucket '{bucket}'.")
+            print("               Verify credentials have s3:HeadBucket / s3:GetBucketLocation permission.")
+        elif code in ("404", "NoSuchBucket"):
+            print(f"        ERROR: Bucket '{bucket}' does not exist.")
+            print("               Check ONEBUCKET_BUCKET.")
+        elif code == "301":
+            print(f"        ERROR: Permanent redirect — region may be wrong (current: {region}).")
+        else:
+            print(f"        ERROR: {code} — {exc.response['Error'].get('Message', str(exc))}")
+        sys.exit(1)
+    except Exception as exc:
+        print()
+        diagnose_connection_error(exc, endpoint, skip_verify)
+        sys.exit(1)
+
+    # 2. Write test object
+    print(f"  [2/4] Writing test object ({TEST_KEY})...")
+    try:
+        client.put_object(Bucket=bucket, Key=TEST_KEY, Body=TEST_BODY)
+        print("        OK")
+    except ClientError as exc:
+        code = exc.response["Error"]["Code"]
+        print(f"        ERROR: Write failed: {code} — {exc.response['Error'].get('Message', str(exc))}")
+        print("               Verify credentials have s3:PutObject permission.")
+        sys.exit(1)
+
+    # 3. Read test object
+    print(f"  [3/4] Reading test object ({TEST_KEY})...")
+    try:
+        resp = client.get_object(Bucket=bucket, Key=TEST_KEY)
+        body = resp["Body"].read()
+        if body != TEST_BODY:
+            print(f"        ERROR: Content mismatch. Expected {TEST_BODY!r}, got {body!r}")
+            sys.exit(1)
+        print("        OK")
+    except ClientError as exc:
+        code = exc.response["Error"]["Code"]
+        print(f"        ERROR: Read failed: {code} — {exc.response['Error'].get('Message', str(exc))}")
+        sys.exit(1)
+
+    # 4. Delete test object
+    print(f"  [4/4] Deleting test object ({TEST_KEY})...")
+    try:
+        client.delete_object(Bucket=bucket, Key=TEST_KEY)
+        print("        OK")
+    except ClientError as exc:
+        code = exc.response["Error"]["Code"]
+        print(f"        WARNING: Delete failed: {code} — manual cleanup may be needed under {TEST_PREFIX}")
+
+    print()
+    print("=" * 60)
+    print("  OneBucket connectivity check PASSED")
+    print("=" * 60)
+    print()
+    print("Next step: make up")
+
+
+if __name__ == "__main__":
+    run_check()

--- a/01_standalone_examples/lakefs-onebucket/scripts/check_onebucket.py
+++ b/01_standalone_examples/lakefs-onebucket/scripts/check_onebucket.py
@@ -19,7 +19,7 @@ from botocore.exceptions import ClientError
 from dotenv import load_dotenv
 
 # Load .env from the project root (one level up from scripts/)
-load_dotenv(Path(__file__).parent.parent / ".env")
+load_dotenv(Path(__file__).parent.parent / ".env", override=True)
 
 TEST_PREFIX = "_lakefs_demo_connectivity_check/"
 TEST_KEY = f"{TEST_PREFIX}test.txt"

--- a/01_standalone_examples/lakefs-onebucket/scripts/init_lakefs.py
+++ b/01_standalone_examples/lakefs-onebucket/scripts/init_lakefs.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+Initialize lakeFS for the OneBucket demo.
+
+Modes (controlled by CREATE_LAKEFS_REPO in .env):
+
+  CREATE_LAKEFS_REPO=true  (default)
+    - Waits for lakeFS to be healthy and authenticated.
+    - Creates the repository named LAKEFS_REPO.
+    - Uses LAKEFS_STORAGE_NAMESPACE as-is if provided, or derives a safe default.
+    - Idempotent: skips creation if the repository already exists.
+
+  CREATE_LAKEFS_REPO=false
+    - Waits for lakeFS to be healthy and authenticated.
+    - Validates that LAKEFS_REPO already exists.
+    - Prints the detected repository info.
+"""
+
+import os
+import sys
+import time
+import urllib.parse
+from pathlib import Path
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+HEALTH_RETRIES = 30
+HEALTH_DELAY = 5  # seconds between retries
+
+
+def get_config() -> dict:
+    return {
+        "endpoint": os.environ.get("LAKEFS_ENDPOINT", "http://localhost:8000").rstrip("/"),
+        "access_key_id": os.environ.get("LAKEFS_ACCESS_KEY_ID", ""),
+        "secret_access_key": os.environ.get("LAKEFS_SECRET_ACCESS_KEY", ""),
+        "repo": os.environ.get("LAKEFS_REPO", "onebucket-demo"),
+        "branch": os.environ.get("LAKEFS_BRANCH", "main"),
+        "storage_namespace": os.environ.get("LAKEFS_STORAGE_NAMESPACE", ""),
+        "bucket": os.environ.get("ONEBUCKET_BUCKET", ""),
+        "create_repo": os.environ.get("CREATE_LAKEFS_REPO", "true").lower() != "false",
+    }
+
+
+def redact(value: str) -> str:
+    if not value:
+        return "(empty)"
+    return (value[:4] + "***") if len(value) > 6 else "***"
+
+
+def api(endpoint: str, path: str) -> str:
+    return f"{endpoint}/api/v1{path}"
+
+
+# ── Health check ────────────────────────────────────────────────────────────
+
+def wait_for_health(endpoint: str) -> None:
+    print(f"Waiting for lakeFS at {endpoint}/_health ...")
+    for attempt in range(1, HEALTH_RETRIES + 1):
+        try:
+            resp = requests.get(f"{endpoint}/_health", timeout=5)
+            if resp.status_code == 200:
+                print("  lakeFS is healthy.\n")
+                return
+        except (requests.ConnectionError, requests.Timeout):
+            pass
+        if attempt < HEALTH_RETRIES:
+            print(f"  Not ready (attempt {attempt}/{HEALTH_RETRIES}), retrying in {HEALTH_DELAY}s...")
+            time.sleep(HEALTH_DELAY)
+
+    print("\nERROR: lakeFS did not become healthy after all retries.")
+    print("  Check container logs: docker compose logs lakefs")
+    sys.exit(1)
+
+
+# ── Auth check ───────────────────────────────────────────────────────────────
+
+def wait_for_auth(endpoint: str, key_id: str, secret: str) -> None:
+    """
+    Poll until credentials are accepted.
+
+    Admin user bootstrap is handled by `make init` via `lakefs setup` before
+    this script runs. A short retry loop here handles the brief window between
+    setup completion and the credential cache becoming active.
+    """
+    print("Verifying lakeFS credentials...")
+    auth = (key_id, secret)
+    for attempt in range(1, HEALTH_RETRIES + 1):
+        try:
+            resp = requests.get(api(endpoint, "/repositories"), auth=auth, timeout=10)
+            if resp.status_code == 200:
+                print("  Credentials accepted.\n")
+                return
+            if resp.status_code in (401, 403):
+                if attempt >= HEALTH_RETRIES:
+                    print(f"\n  ERROR: Authentication failed (HTTP {resp.status_code}).")
+                    print("  Check LAKEFS_ACCESS_KEY_ID and LAKEFS_SECRET_ACCESS_KEY in .env.")
+                    print("  Check container logs: docker compose logs lakefs")
+                    sys.exit(1)
+        except (requests.ConnectionError, requests.Timeout):
+            pass
+        if attempt < HEALTH_RETRIES:
+            time.sleep(HEALTH_DELAY)
+
+    print("ERROR: Could not authenticate with lakeFS after all retries.")
+    sys.exit(1)
+
+
+# ── Storage namespace ─────────────────────────────────────────────────────────
+
+def resolve_storage_namespace(ns: str, bucket: str, repo: str) -> str:
+    if not ns:
+        if not bucket:
+            print("ERROR: LAKEFS_STORAGE_NAMESPACE is empty and ONEBUCKET_BUCKET is not set.")
+            print("  Set LAKEFS_STORAGE_NAMESPACE or ONEBUCKET_BUCKET in .env.")
+            sys.exit(1)
+        derived = f"s3://{bucket}/lakefs/{repo}/"
+        print(f"  LAKEFS_STORAGE_NAMESPACE not set — using derived default: {derived}")
+        return derived
+    return ns
+
+
+def validate_storage_namespace(ns: str) -> None:
+    if not ns.startswith("s3://"):
+        print(f"ERROR: LAKEFS_STORAGE_NAMESPACE must start with s3://")
+        print(f"  Got: {ns!r}")
+        sys.exit(1)
+
+    parsed = urllib.parse.urlparse(ns)
+    path = parsed.path.lstrip("/").rstrip("/")
+
+    if not path:
+        # e.g. s3://my-bucket  or  s3://my-bucket/
+        print(f"  WARNING: Storage namespace is the bucket root: {ns}")
+        print("           lakeFS metadata and demo data will sit at the root.")
+        print("           A prefix (e.g. s3://my-bucket/lakefs/my-repo/) is safer for cleanup.")
+
+
+# ── Repository operations ────────────────────────────────────────────────────
+
+def create_repository(endpoint: str, auth: tuple, repo: str, branch: str, ns: str) -> None:
+    print(f"Creating lakeFS repository: {repo}")
+    print(f"  Storage namespace: {ns}")
+    print(f"  Default branch:    {branch}")
+
+    resp = requests.post(
+        api(endpoint, "/repositories"),
+        auth=auth,
+        json={"name": repo, "storage_namespace": ns, "default_branch": branch},
+        timeout=30,
+    )
+
+    if resp.status_code == 201:
+        data = resp.json()
+        print("\nRepository created successfully.")
+        _print_repo_data(data)
+    elif resp.status_code == 409:
+        print("  Repository already exists — skipping creation (idempotent).")
+        _fetch_and_print_repo(endpoint, auth, repo)
+    else:
+        print(f"\nERROR: Failed to create repository (HTTP {resp.status_code})")
+        _print_api_error(resp)
+        sys.exit(1)
+
+
+def validate_existing_repository(endpoint: str, auth: tuple, repo: str) -> None:
+    print(f"Validating existing repository: {repo}")
+    resp = requests.get(api(endpoint, f"/repositories/{repo}"), auth=auth, timeout=10)
+    if resp.status_code == 200:
+        print("  Repository found.")
+        _print_repo_data(resp.json())
+    elif resp.status_code == 404:
+        print(f"\nERROR: Repository '{repo}' was not found in lakeFS.")
+        print("  Options:")
+        print("    1. Set CREATE_LAKEFS_REPO=true in .env to auto-create it, or")
+        print("    2. Create the repository manually via the lakeFS UI or API.")
+        sys.exit(1)
+    else:
+        print(f"\nERROR: Unexpected response (HTTP {resp.status_code})")
+        _print_api_error(resp)
+        sys.exit(1)
+
+
+def _fetch_and_print_repo(endpoint: str, auth: tuple, repo: str) -> None:
+    try:
+        resp = requests.get(api(endpoint, f"/repositories/{repo}"), auth=auth, timeout=10)
+        if resp.status_code == 200:
+            _print_repo_data(resp.json())
+    except Exception:
+        pass
+
+
+def _print_repo_data(data: dict) -> None:
+    print(f"  Name:              {data.get('id', '?')}")
+    print(f"  Storage namespace: {data.get('storage_namespace', '?')}")
+    print(f"  Default branch:    {data.get('default_branch', '?')}")
+
+
+def _print_api_error(resp: requests.Response) -> None:
+    try:
+        print(f"  Detail: {resp.json()}")
+    except Exception:
+        print(f"  Body:   {resp.text[:300]}")
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    cfg = get_config()
+
+    print("=" * 60)
+    print("  lakeFS initialization")
+    print("=" * 60)
+    print(f"\n  Endpoint:    {cfg['endpoint']}")
+    print(f"  Access key:  {redact(cfg['access_key_id'])}")
+    print(f"  Repository:  {cfg['repo']}")
+    print(f"  Branch:      {cfg['branch']}")
+    print(f"  Create repo: {cfg['create_repo']}")
+    print()
+
+    if not cfg["access_key_id"] or not cfg["secret_access_key"]:
+        print("ERROR: LAKEFS_ACCESS_KEY_ID or LAKEFS_SECRET_ACCESS_KEY is not set in .env.")
+        sys.exit(1)
+
+    wait_for_health(cfg["endpoint"])
+    wait_for_auth(cfg["endpoint"], cfg["access_key_id"], cfg["secret_access_key"])
+
+    auth = (cfg["access_key_id"], cfg["secret_access_key"])
+
+    if cfg["create_repo"]:
+        ns = resolve_storage_namespace(cfg["storage_namespace"], cfg["bucket"], cfg["repo"])
+        validate_storage_namespace(ns)
+        create_repository(cfg["endpoint"], auth, cfg["repo"], cfg["branch"], ns)
+    else:
+        validate_existing_repository(cfg["endpoint"], auth, cfg["repo"])
+
+    print()
+    print("=" * 60)
+    print(f"  lakeFS UI: {cfg['endpoint']}/repositories/{cfg['repo']}/objects")
+    print("=" * 60)
+    print()
+    print("Next step: make demo")
+
+
+if __name__ == "__main__":
+    main()

--- a/01_standalone_examples/lakefs-onebucket/scripts/init_lakefs.py
+++ b/01_standalone_examples/lakefs-onebucket/scripts/init_lakefs.py
@@ -25,7 +25,7 @@ from pathlib import Path
 import requests
 from dotenv import load_dotenv
 
-load_dotenv(Path(__file__).parent.parent / ".env")
+load_dotenv(Path(__file__).parent.parent / ".env", override=True)
 
 HEALTH_RETRIES = 30
 HEALTH_DELAY = 5  # seconds between retries

--- a/01_standalone_examples/lakefs-onebucket/scripts/run_demo.py
+++ b/01_standalone_examples/lakefs-onebucket/scripts/run_demo.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""
+lakeFS + OneBucket demo workflow.
+
+All data access goes through the lakeFS S3 Gateway and REST API.
+Nothing is written directly to OneBucket in this script.
+
+Flow:
+  1. Upload raw/customers.csv  → main branch (via lakeFS S3 Gateway)
+  2. Commit on main
+  3. Create 'experiment' branch from main
+  4. Upload processed/customers_clean.csv → experiment branch (via lakeFS S3 Gateway)
+  5. Commit on experiment
+  6. [optional] Merge experiment → main  (MERGE_EXPERIMENT=true)
+  7. List objects on both branches
+  8. Read objects back
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import boto3
+import requests
+from botocore.config import Config
+from botocore.exceptions import ClientError
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+# ── Sample data ───────────────────────────────────────────────────────────────
+
+RAW_CSV = b"""\
+id,name,email,signup_date
+1,Alice Smith,alice@example.com,2024-01-10
+2,Bob Jones,bob@example.com,2024-02-14
+3,Carol White,carol@example.com,2024-03-22
+"""
+
+CLEAN_CSV = b"""\
+id,name,email,signup_year
+1,Alice Smith,alice@example.com,2024
+2,Bob Jones,bob@example.com,2024
+3,Carol White,carol@example.com,2024
+"""
+
+EXPERIMENT_BRANCH = "experiment"
+
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+def get_config() -> dict:
+    return {
+        "endpoint": os.environ.get("LAKEFS_ENDPOINT", "http://localhost:8000").rstrip("/"),
+        "access_key": os.environ.get("LAKEFS_ACCESS_KEY_ID", ""),
+        "secret_key": os.environ.get("LAKEFS_SECRET_ACCESS_KEY", ""),
+        "repo": os.environ.get("LAKEFS_REPO", "onebucket-demo"),
+        "branch": os.environ.get("LAKEFS_BRANCH", "main"),
+        "merge": os.environ.get("MERGE_EXPERIMENT", "false").lower() == "true",
+    }
+
+
+# ── S3 client (lakeFS Gateway) ────────────────────────────────────────────────
+
+def make_lakefs_s3_client(endpoint: str, access_key: str, secret_key: str) -> boto3.client:
+    """
+    boto3 client pointed at the lakeFS S3 Gateway.
+
+    - addressing_style=path: lakeFS gateway requires path-style URLs.
+    - checksum settings: disable automatic checksum negotiation that some
+      lakeFS gateway versions reject.
+    """
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name="us-east-1",
+        config=Config(
+            s3={"addressing_style": "path"},
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
+        ),
+    )
+
+
+# ── lakeFS REST API helpers ───────────────────────────────────────────────────
+
+def api(endpoint: str, path: str) -> str:
+    return f"{endpoint}/api/v1{path}"
+
+
+def lfs_commit(endpoint: str, auth: tuple, repo: str, branch: str, message: str) -> str:
+    resp = requests.post(
+        api(endpoint, f"/repositories/{repo}/branches/{branch}/commits"),
+        auth=auth,
+        json={"message": message},
+        timeout=30,
+    )
+    if resp.status_code not in (200, 201):
+        print(f"  ERROR: Commit failed (HTTP {resp.status_code}): {resp.text[:200]}")
+        sys.exit(1)
+    return resp.json().get("id", "unknown")
+
+
+def lfs_create_branch(endpoint: str, auth: tuple, repo: str, name: str, source: str) -> None:
+    resp = requests.post(
+        api(endpoint, f"/repositories/{repo}/branches"),
+        auth=auth,
+        json={"name": name, "source": source},
+        timeout=10,
+    )
+    if resp.status_code == 409:
+        print(f"  Branch '{name}' already exists — reusing.")
+        return
+    if resp.status_code not in (200, 201):
+        print(f"  ERROR: Create branch failed (HTTP {resp.status_code}): {resp.text[:200]}")
+        sys.exit(1)
+
+
+def lfs_merge(endpoint: str, auth: tuple, repo: str, source: str, dest: str) -> str:
+    resp = requests.post(
+        api(endpoint, f"/repositories/{repo}/refs/{source}/merge/{dest}"),
+        auth=auth,
+        json={},
+        timeout=30,
+    )
+    if resp.status_code not in (200, 201):
+        print(f"  ERROR: Merge failed (HTTP {resp.status_code}): {resp.text[:200]}")
+        sys.exit(1)
+    return resp.json().get("reference", "unknown")
+
+
+# ── S3 helpers (via lakeFS gateway) ──────────────────────────────────────────
+
+def put_object(s3: boto3.client, repo: str, key: str, body: bytes) -> None:
+    try:
+        s3.put_object(Bucket=repo, Key=key, Body=body)
+    except ClientError as exc:
+        code = exc.response["Error"]["Code"]
+        msg = exc.response["Error"].get("Message", str(exc))
+        print(f"  ERROR: PutObject failed: {code} — {msg}")
+        sys.exit(1)
+
+
+def list_branch_objects(s3: boto3.client, repo: str, branch: str) -> list[str]:
+    """Return the logical paths (strip the branch/ prefix) of all objects on a branch."""
+    prefix = f"{branch}/"
+    paginator = s3.get_paginator("list_objects_v2")
+    paths: list[str] = []
+    try:
+        for page in paginator.paginate(Bucket=repo, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                paths.append(obj["Key"][len(prefix):])
+    except ClientError as exc:
+        print(f"  WARNING: ListObjects failed: {exc.response['Error']['Code']}")
+    return paths
+
+
+def read_object(s3: boto3.client, repo: str, key: str) -> bytes | None:
+    try:
+        resp = s3.get_object(Bucket=repo, Key=key)
+        return resp["Body"].read()
+    except ClientError as exc:
+        print(f"  WARNING: GetObject '{key}' failed: {exc.response['Error']['Code']}")
+        return None
+
+
+# ── Demo steps ────────────────────────────────────────────────────────────────
+
+def sep() -> None:
+    print("-" * 60)
+
+
+def main() -> None:
+    cfg = get_config()
+    endpoint = cfg["endpoint"]
+    repo = cfg["repo"]
+    main_branch = cfg["branch"]
+    auth = (cfg["access_key"], cfg["secret_key"])
+
+    print("=" * 60)
+    print("  lakeFS + OneBucket demo")
+    print("=" * 60)
+    print(f"  lakeFS endpoint:  {endpoint}")
+    print(f"  Repository:       {repo}")
+    print(f"  Main branch:      {main_branch}")
+    print(f"  Merge experiment: {cfg['merge']}")
+    print("=" * 60)
+    print()
+
+    if not cfg["access_key"] or not cfg["secret_key"]:
+        print("ERROR: LAKEFS_ACCESS_KEY_ID or LAKEFS_SECRET_ACCESS_KEY is not set in .env.")
+        sys.exit(1)
+
+    s3 = make_lakefs_s3_client(endpoint, cfg["access_key"], cfg["secret_key"])
+
+    # ── Step 1: upload raw CSV to main ───────────────────────────────────────
+    sep()
+    raw_key = f"{main_branch}/raw/customers.csv"
+    print(f"[1] Writing object through lakeFS S3 Gateway:")
+    print(f"    Bucket: {repo}  Key: {raw_key}")
+    put_object(s3, repo, raw_key, RAW_CSV)
+    print("    OK")
+
+    # ── Step 2: commit on main ───────────────────────────────────────────────
+    sep()
+    print(f"[2] Committing to '{main_branch}'...")
+    main_commit = lfs_commit(endpoint, auth, repo, main_branch, "Add raw customer data")
+    print(f"    Commit ID: {main_commit}")
+
+    # ── Step 3: create experiment branch ─────────────────────────────────────
+    sep()
+    print(f"[3] Creating branch '{EXPERIMENT_BRANCH}' from '{main_branch}'...")
+    lfs_create_branch(endpoint, auth, repo, EXPERIMENT_BRANCH, main_branch)
+    print("    OK")
+
+    # ── Step 4: upload processed CSV to experiment ────────────────────────────
+    sep()
+    clean_key = f"{EXPERIMENT_BRANCH}/processed/customers_clean.csv"
+    print(f"[4] Writing transformed object through lakeFS S3 Gateway:")
+    print(f"    Bucket: {repo}  Key: {clean_key}")
+    put_object(s3, repo, clean_key, CLEAN_CSV)
+    print("    OK")
+
+    # ── Step 5: commit on experiment ─────────────────────────────────────────
+    sep()
+    print(f"[5] Committing to '{EXPERIMENT_BRANCH}'...")
+    exp_commit = lfs_commit(endpoint, auth, repo, EXPERIMENT_BRANCH, "Add processed customer data")
+    print(f"    Commit ID: {exp_commit}")
+
+    # ── Step 6: optional merge ────────────────────────────────────────────────
+    merge_ref: str | None = None
+    sep()
+    if cfg["merge"]:
+        print(f"[6] Merging '{EXPERIMENT_BRANCH}' → '{main_branch}'...")
+        merge_ref = lfs_merge(endpoint, auth, repo, EXPERIMENT_BRANCH, main_branch)
+        print(f"    Merge commit: {merge_ref}")
+    else:
+        print(f"[6] Skipping merge (set MERGE_EXPERIMENT=true in .env to enable)")
+
+    # ── Step 7: list objects on both branches ─────────────────────────────────
+    sep()
+    print(f"[7] Objects on '{main_branch}':")
+    main_objects = list_branch_objects(s3, repo, main_branch)
+    for path in main_objects:
+        print(f"    {path}")
+    if not main_objects:
+        print("    (none)")
+
+    print(f"\n    Objects on '{EXPERIMENT_BRANCH}':")
+    exp_objects = list_branch_objects(s3, repo, EXPERIMENT_BRANCH)
+    for path in exp_objects:
+        print(f"    {path}")
+    if not exp_objects:
+        print("    (none)")
+
+    # ── Step 8: read back ─────────────────────────────────────────────────────
+    sep()
+    print("[8] Reading objects back...")
+    raw_data = read_object(s3, repo, raw_key)
+    if raw_data is not None:
+        print(f"    {raw_key}: {len(raw_data)} bytes — OK")
+    clean_data = read_object(s3, repo, clean_key)
+    if clean_data is not None:
+        print(f"    {clean_key}: {len(clean_data)} bytes — OK")
+
+    # ── Summary ───────────────────────────────────────────────────────────────
+    sep()
+    print()
+    print("=" * 60)
+    print("  Demo Summary")
+    print("=" * 60)
+    print(f"  Repository:            {repo}")
+    print(f"  Main commit:           {main_commit}")
+    print(f"  Experiment commit:     {exp_commit}")
+    if merge_ref:
+        print(f"  Merge commit:          {merge_ref}")
+    print(f"  Objects on main:       {len(main_objects)}")
+    print(f"  Objects on experiment: {len(exp_objects)}")
+    print()
+    print("  Demo completed successfully.")
+    print()
+    print(f"  lakeFS UI: {endpoint}/repositories/{repo}/objects")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/01_standalone_examples/lakefs-onebucket/scripts/run_demo.py
+++ b/01_standalone_examples/lakefs-onebucket/scripts/run_demo.py
@@ -26,7 +26,7 @@ from botocore.config import Config
 from botocore.exceptions import ClientError
 from dotenv import load_dotenv
 
-load_dotenv(Path(__file__).parent.parent / ".env")
+load_dotenv(Path(__file__).parent.parent / ".env", override=True)
 
 # ── Sample data ───────────────────────────────────────────────────────────────
 

--- a/01_standalone_examples/lakefs-onebucket/scripts/run_demo.py
+++ b/01_standalone_examples/lakefs-onebucket/scripts/run_demo.py
@@ -14,6 +14,9 @@ Flow:
   6. [optional] Merge experiment → main  (MERGE_EXPERIMENT=true)
   7. List objects on both branches
   8. Read objects back
+
+Safe to run more than once: re-runs upload identical content, so the commit
+and merge steps report "no changes" and reuse the existing commits.
 """
 
 import os
@@ -90,6 +93,18 @@ def api(endpoint: str, path: str) -> str:
     return f"{endpoint}/api/v1{path}"
 
 
+def lfs_branch_head(endpoint: str, auth: tuple, repo: str, branch: str) -> str:
+    """Current commit ID at the tip of a branch."""
+    resp = requests.get(
+        api(endpoint, f"/repositories/{repo}/branches/{branch}"),
+        auth=auth,
+        timeout=10,
+    )
+    if resp.status_code != 200:
+        return "unknown"
+    return resp.json().get("commit_id", "unknown")
+
+
 def lfs_commit(endpoint: str, auth: tuple, repo: str, branch: str, message: str) -> str:
     resp = requests.post(
         api(endpoint, f"/repositories/{repo}/branches/{branch}/commits"),
@@ -97,6 +112,12 @@ def lfs_commit(endpoint: str, auth: tuple, repo: str, branch: str, message: str)
         json={"message": message},
         timeout=30,
     )
+    # Re-running the demo uploads byte-identical content, so there is nothing
+    # to commit. That is expected — report the existing head instead of failing.
+    if resp.status_code == 400 and "no changes" in resp.text.lower():
+        head = lfs_branch_head(endpoint, auth, repo, branch)
+        print("    No changes to commit — content is identical to a previous run.")
+        return head
     if resp.status_code not in (200, 201):
         print(f"  ERROR: Commit failed (HTTP {resp.status_code}): {resp.text[:200]}")
         sys.exit(1)
@@ -125,6 +146,11 @@ def lfs_merge(endpoint: str, auth: tuple, repo: str, source: str, dest: str) -> 
         json={},
         timeout=30,
     )
+    # Already merged by a previous run — nothing to do.
+    if resp.status_code == 400 and "no changes" in resp.text.lower():
+        head = lfs_branch_head(endpoint, auth, repo, dest)
+        print(f"    '{source}' is already merged into '{dest}'.")
+        return head
     if resp.status_code not in (200, 201):
         print(f"  ERROR: Merge failed (HTTP {resp.status_code}): {resp.text[:200]}")
         sys.exit(1)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Under the [standalone_examples](./01_standalone_examples/) folder are a set of e
 * [How to backup, migrate or clone a repo](./01_standalone_examples/backup-migrate-or-clone-repo/)
 * [Running lakeFS with PostgreSQL as K/V store](./01_standalone_examples/docker-compose-with-postgres/)
 * [Running lakeFS with NetApp ONTAP storage](./01_standalone_examples/netapp-ontap/)
+* [Running lakeFS with OneBucket (Attimis) as an S3-compatible blockstore](./01_standalone_examples/lakefs-onebucket/)
 
 ## Got Questions or Want to Chat?
 


### PR DESCRIPTION
## What

Adds `01_standalone_examples/lakefs-onebucket` — a self-contained local demo that runs
lakeFS against [OneBucket by Attimis](https://onebucket.io) as its S3-compatible
blockstore, plus an index entry in the root README next to the NetApp ONTAP example.

lakeFS and PostgreSQL run locally in Docker; all blockstore objects land in OneBucket
over the S3 API. No cloud infrastructure to provision — you need an endpoint, a bucket,
and a key pair.

## The demo flow

`make demo` drives a versioned-dataset workflow entirely through the lakeFS S3 Gateway
and REST API:

1. Upload `raw/customers.csv` to `main`, commit
2. Branch `experiment` off `main`
3. Upload `processed/customers_clean.csv` to `experiment`, commit
4. Optionally merge back (`MERGE_EXPERIMENT=true`)
5. List and read back objects on both branches

`check_onebucket.py` is the only script that touches the object store directly — a
pre-flight write/read/delete under a dedicated prefix that cleans up after itself.

## Layout

| Path | Purpose |
|------|---------|
| `Makefile` | `setup` → `check-onebucket` → `up` → `init` → `demo` |
| `docker-compose.yml` | lakeFS + PostgreSQL, all config from `.env` |
| `scripts/check_onebucket.py` | Pre-flight connectivity check with actionable diagnostics |
| `scripts/init_lakefs.py` | Creates or validates the repository (idempotent) |
| `scripts/run_demo.py` | The demo workflow |
| `docs/troubleshooting.md` | Common failures and fixes |
| `docs/onebucket-notes.md` | Why each S3-compatibility setting is needed |
| `.env.example` | Config template — placeholders only |

## Notes for reviewers

- **No credentials committed.** `.env` is gitignored; `.env.example` carries placeholders
  only. Both were scanned before submitting.
- The demo supports two modes via `CREATE_LAKEFS_REPO` — auto-create the repo, or
  validate one you made yourself in the UI.
- Three settings matter for S3-compatible stores generally, and are documented in
  `docs/onebucket-notes.md`: path-style addressing, an explicit region with bucket-region
  discovery disabled (`GetBucketLocation` isn't always implemented), and streaming
  chunked encoding turned off.
- The configuration here was arrived at against a live OneBucket endpoint.
