### PR TITLE
Remove Dockerhub login instructions from README

### DIFF
--- a/01_standalone_examples/lakefs-mount-demo/README.md
+++ b/01_standalone_examples/lakefs-mount-demo/README.md
@@ -36,13 +36,7 @@ This demo includes a Jupyter Notebook which you can run on your local machine.
 
    ### **Don't have a lakeFS Enterprise Server or Object Store?**
 
-   If you want to provision a lakeFS Enterprise server as well as MinIO for your object store, plus Jupyter then first login to [Treeverse Dockerhub](https://hub.docker.com/u/treeverse) by using the granted token so lakeFS Enterprise proprietary image can be retrieved:
-
-   ```bash
-   docker login -u externallakefs
-   ```
-
-   Copy the lakeFS license file to "lakeFS-samples/01_standalone_examples/lakefs-mount-demo" folder,
+   If you want to provision a lakeFS Enterprise server as well as MinIO for your object store, plus Jupyter then copy the lakeFS license file to "lakeFS-samples/01_standalone_examples/lakefs-mount-demo" folder,
    then change lakeFS license file name and installation ID in the following command and run the command to bring up the full stack:
    ```bash
    LAKEFS_LICENSE_FILE_NAME=license-org-name-installation-id.token LAKEFS_INSTALLATION_ID=installation-id docker compose --profile local-lakefs-enterprise up

--- a/01_standalone_examples/lakefs-sso/README.md
+++ b/01_standalone_examples/lakefs-sso/README.md
@@ -30,10 +30,7 @@ We will use [Keycloak](https://www.keycloak.org/) Docker image as our local SSO 
    git clone https://github.com/treeverse/lakeFS-samples
    cd lakeFS-samples/01_standalone_examples/lakefs-sso
   ```
-2. Login to [Treeverse Dockerhub](https://hub.docker.com/u/treeverse) by using the granted token so lakeFS Enterprise proprietary image can be retrieved. [Contact Sales](https://lakefs.io/contact-sales/) to get the token and license file for lakeFS Enterprise:
-  ```bash
-   docker login -u externallakefs
-  ```
+2. [Contact Sales](https://lakefs.io/contact-sales/) to get the license file for lakeFS Enterprise.
 3. Copy the lakeFS license file to `lakeFS-samples/01_standalone_examples/lakefs-sso` folder, then change lakeFS license file name and installation ID in the following command and run the command to provision the full stack which includes lakeFS Enterprise and Keycloak:
   ```bash
    LAKEFS_LICENSE_FILE_NAME=license-org-name-installation-id.token LAKEFS_INSTALLATION_ID=installation-id docker compose up

--- a/01_standalone_examples/multimodal-data-demo-local/README.md
+++ b/01_standalone_examples/multimodal-data-demo-local/README.md
@@ -28,12 +28,7 @@ In the ever-evolving landscape of machine learning (ML), data stands as the corn
    cd lakeFS-samples/01_standalone_examples/multimodal-data-demo-local
    ```
 
-2. Login to [Treeverse Dockerhub](https://hub.docker.com/u/treeverse) by using the granted token so lakeFS Enterprise proprietary image can be retrieved. [Contact Sales](https://lakefs.io/contact-sales/) to get the token and license file for lakeFS Enterprise:
-
-   ```bash
-   docker login -u externallakefs
-   ```
-
+2. [Contact Sales](https://lakefs.io/contact-sales/) to get the license file for lakeFS Enterprise.
 
 3. Copy the lakeFS license file to "lakeFS-samples/01_standalone_examples/multimodal-data-demo-local" folder, then change lakeFS license file name and installation ID in the following command and run the command to provision the full stack which includes lakeFS Enterprise, MinIO, Python, Spark, Jupyter Notebook, JDK, Hadoop binaries and lakeFS Python client
 

--- a/02_lakefs_enterprise/README.md
+++ b/02_lakefs_enterprise/README.md
@@ -13,14 +13,6 @@ git clone https://github.com/treeverse/lakeFS-samples.git
 cd lakeFS-samples/02_lakefs_enterprise
 ```
 
-##### **Login to Treeverse Dockerhub**
-
-Login to [Treeverse Dockerhub](https://hub.docker.com/u/treeverse) by using the granted token so lakeFS Enterprise proprietary image can be retrieved. [Contact Sales](https://lakefs.io/contact-sales/) to get the token and license file for lakeFS Enterprise:
-
-```bash
-docker login -u externallakefs
-```
-
 ##### **Multiple Storage Backends**
 
 If you want to use lakeFS [Multiple Storage Backends](https://docs.lakefs.io/latest/howto/multiple-storage-backends/) feature then change "lakeFS-samples/02_lakefs_enterprise/docker-compose.yml" file to update credentials for AWS S3 and/or Azure Blob Storage. If you want to use Google Cloud Storage (GCS) then copy GCP Service Account key JSON file to "lakeFS-samples/02_lakefs_enterprise" folder and change the file name in Docker Compose file. Refer to [Multiple Storage Backends documentation](https://docs.lakefs.io/latest/howto/multiple-storage-backends/) for additional information.

--- a/02_lakefs_enterprise/README.md
+++ b/02_lakefs_enterprise/README.md
@@ -6,6 +6,8 @@
 
 ## Let's Get Started 👩🏻‍💻
 
+[Contact Sales](https://lakefs.io/contact-sales/) to get the license file for lakeFS Enterprise.
+
 Clone this repository
 
 ```bash


### PR DESCRIPTION
Removed instructions for logging into Treeverse Dockerhub and obtaining a token for lakeFS Enterprise.